### PR TITLE
Use app_dirs2 to get the holochain_dir() in dev mode in Android

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,4 @@
 [workspace]
 members = ["crates/*"]
 resolver = "2"
-exclude = ["examples/holochain-runtime", "nix/reference-tauri-happ"]
+exclude = ["examples/end-user-happ", "examples/holochain-runtime", "nix/reference-tauri-happ"]

--- a/crates/scaffold-holochain-runtime/run_test.sh
+++ b/crates/scaffold-holochain-runtime/run_test.sh
@@ -8,7 +8,7 @@ rm -rf /tmp/test-scaffold-holochain-runtime
 nix run --accept-flake-config .#scaffold-holochain-runtime -- --name test-scaffold-holochain-runtime --path /tmp --bundle-identifier org.myorg.testscaffoldholochainruntime
 cd /tmp/test-scaffold-holochain-runtime
 
-nix flake update
+nix flake update --override-input p2p-shipyard $DIR
 nix develop --override-input p2p-shipyard $DIR --command bash -c "
 set -e
 npm i

--- a/crates/scaffold-holochain-runtime/templates/holochain-runtime/.github/workflows/release-tauri-app.yaml.hbs
+++ b/crates/scaffold-holochain-runtime/templates/holochain-runtime/.github/workflows/release-tauri-app.yaml.hbs
@@ -9,7 +9,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platform: [windows-2019, macos-11, ubuntu-22.04]
+        include:
+          - platform: 'macos-latest' # for Arm based macs (M1 and above).
+            args: '--target aarch64-apple-darwin'
+          - platform: 'macos-latest' # for Intel based macs.
+            args: '--target x86_64-apple-darwin'
+          - platform: 'ubuntu-22.04' # for Tauri v1 you could replace this with ubuntu-20.04.
+            args: ''
+          - platform: 'windows-latest'
+            args: ''
     env:
       MACOSX_DEPLOYMENT_TARGET: 10.13
 
@@ -27,11 +35,17 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: 20
+
       - name: install Rust stable
         uses: actions-rs/toolchain@v1
         with:
           override: true
           toolchain: stable
+
+      - name: install x86_64 target
+        if: matrix.args == '--target x86_64-apple-darwin'
+        run: rustup target add x86_64-apple-darwin
+
       - name: install Go stable
         uses: actions/setup-go@v4
         with:
@@ -68,3 +82,4 @@ jobs:
           releaseBody: "See assets below to download and install this version."
           releaseDraft: true
           prerelease: true
+          args: $\{{ matrix.args }}

--- a/crates/scaffold-holochain-runtime/templates/holochain-runtime/src-tauri/src/lib.rs.hbs
+++ b/crates/scaffold-holochain-runtime/templates/holochain-runtime/src-tauri/src/lib.rs.hbs
@@ -79,12 +79,26 @@ fn signal_url() -> Url2 {
 
 fn holochain_dir() -> PathBuf {
     if tauri::is_dev() {
-        let tmp_dir = tempdir::TempDir::new("{{runtime_name}}").expect("Could not create temporary directory");
+        #[cfg(target_os = "android")]
+        {
+            app_dirs2::app_root(
+                app_dirs2::AppDataType::UserCache,
+                &app_dirs2::AppInfo {
+                    name: "{{runtime_name}}",
+                    author: std::env!("CARGO_PKG_AUTHORS"),
+                },
+            ).expect("Could not get the UserCache directory")
+        }
+        #[cfg(not(target_os = "android"))]
+        {
+            let tmp_dir =
+                tempdir::TempDir::new("{{runtime_name}}").expect("Could not create temporary directory");
 
-        // Convert `tmp_dir` into a `Path`, destroying the `TempDir`
-        // without deleting the directory.
-        let tmp_path = tmp_dir.into_path();
-        tmp_path
+            // Convert `tmp_dir` into a `Path`, destroying the `TempDir`
+            // without deleting the directory.
+            let tmp_path = tmp_dir.into_path();
+            tmp_path
+        }
     } else {
         app_dirs2::app_root(
             app_dirs2::AppDataType::UserData,

--- a/crates/scaffold-tauri-happ/run_test.sh
+++ b/crates/scaffold-tauri-happ/run_test.sh
@@ -13,7 +13,7 @@ nix flake update
 nix develop --command bash -c \"npm i && hc scaffold dna forum && hc scaffold zome posts --integrity dnas/forum/zomes/integrity/ --coordinator dnas/forum/zomes/coordinator/\"
 "
 
-nix run --accept-flake-config  .#scaffold-tauri-happ -- --path /tmp/forum-scaffold-tauri-happ --ui-package ui --bundle-identifier org.myorg.myapp
+nix run --accept-flake-config .#scaffold-tauri-happ -- --path /tmp/forum-scaffold-tauri-happ --ui-package ui --bundle-identifier org.myorg.myapp
 
 cd /tmp/forum-scaffold-tauri-happ
 

--- a/crates/scaffold-tauri-happ/templates/end-user-happ/.github/workflows/release-tauri-app.yaml.hbs
+++ b/crates/scaffold-tauri-happ/templates/end-user-happ/.github/workflows/release-tauri-app.yaml.hbs
@@ -108,6 +108,10 @@ jobs:
         with:
           override: true
           toolchain: stable
+    
+      - name: install x86_64 target
+        if: matrix.args == '--target x86_64-apple-darwin'
+        run: rustup target add x86_64-apple-darwin
 
       - name: install Go stable
         uses: actions/setup-go@v4

--- a/crates/scaffold-tauri-happ/templates/end-user-happ/src-tauri/src/lib.rs.hbs
+++ b/crates/scaffold-tauri-happ/templates/end-user-happ/src-tauri/src/lib.rs.hbs
@@ -129,12 +129,26 @@ fn signal_url() -> Url2 {
 
 fn holochain_dir() -> PathBuf {
     if tauri::is_dev() {
-        let tmp_dir = tempdir::TempDir::new("{{app_name}}").expect("Could not create temporary directory");
+        #[cfg(target_os = "android")]
+        {
+            app_dirs2::app_root(
+                app_dirs2::AppDataType::UserCache,
+                &app_dirs2::AppInfo {
+                    name: "{{app_name}}",
+                    author: std::env!("CARGO_PKG_AUTHORS"),
+                },
+            ).expect("Could not get the UserCache directory")
+        }
+        #[cfg(not(target_os = "android"))]
+        {
+            let tmp_dir =
+                tempdir::TempDir::new("{{app_name}}").expect("Could not create temporary directory");
 
-        // Convert `tmp_dir` into a `Path`, destroying the `TempDir`
-        // without deleting the directory.
-        let tmp_path = tmp_dir.into_path();
-        tmp_path
+            // Convert `tmp_dir` into a `Path`, destroying the `TempDir`
+            // without deleting the directory.
+            let tmp_path = tmp_dir.into_path();
+            tmp_path
+        }
     } else {
         app_dirs2::app_root(
             app_dirs2::AppDataType::UserData,

--- a/examples/end-user-happ/Cargo.lock
+++ b/examples/end-user-happ/Cargo.lock
@@ -981,9 +981,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.1.5"
+version = "1.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "324c74f2155653c90b04f25b2a47a8a631360cb908f92a772695f430c7e31052"
+checksum = "2aba8f4e9906c7ce3c73463f62a7f0c65183ada1a2d47e397cc8810827f9694f"
 dependencies = [
  "jobserver",
  "libc",
@@ -2067,7 +2067,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "example"
+name = "example-end-user-happ"
 version = "0.0.0"
 dependencies = [
  "anyhow",
@@ -4838,7 +4838,7 @@ dependencies = [
  "tar",
  "ureq",
  "vcpkg",
- "zip 2.1.3",
+ "zip 2.1.4",
 ]
 
 [[package]]
@@ -10769,9 +10769,9 @@ dependencies = [
 
 [[package]]
 name = "zip"
-version = "2.1.3"
+version = "2.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "775a2b471036342aa69bc5a602bc889cb0a06cda00477d0c69566757d5553d39"
+checksum = "e29ab4097989787b2029a5981c41b7bfb427b5a601e23f455daacb4d0360a9e9"
 dependencies = [
  "arbitrary",
  "crc32fast",

--- a/examples/end-user-happ/flake.lock
+++ b/examples/end-user-happ/flake.lock
@@ -10,11 +10,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1720556331,
-        "narHash": "sha256-DeYdbpVgxREy83sIAEl2VYQNMf9biisJpWdIhyr83IQ=",
+        "lastModified": 1720988234,
+        "narHash": "sha256-OzqdY+tTyT6bPNi/jFt2lFmy3nLr7qyhm+0hd5QovgY=",
         "owner": "tadfisher",
         "repo": "android-nixpkgs",
-        "rev": "f569fc8ebcb64977ae68b8786f1501053dd858ce",
+        "rev": "4aeeeec599210e54aee0ac31d4fcb512f87351a0",
         "type": "github"
       },
       "original": {
@@ -484,11 +484,11 @@
         "versions": "versions"
       },
       "locked": {
-        "lastModified": 1720422695,
-        "narHash": "sha256-GlMSIWEurskANa6CKKan66KK46CGREYFQc5domI9rwM=",
+        "lastModified": 1721334614,
+        "narHash": "sha256-it35pISG3CET1w664PW1gMaxisSuH1/hN4znOfgjn5A=",
         "owner": "holochain-open-dev",
         "repo": "infrastructure",
-        "rev": "9224b5e082396b694655fd1a6883bd73990ec540",
+        "rev": "24ec261f2379370adf0f80feb3a5e2a33f827a6a",
         "type": "github"
       },
       "original": {
@@ -532,11 +532,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1721208140,
-        "narHash": "sha256-e3p0PG/esuzIFanq4RfYyfI2cfOapoHmqWo4Z+9HcBQ=",
+        "lastModified": 1721389195,
+        "narHash": "sha256-xeMjtS0w9iPGAnLqsrkg3PG4kqzQ8ud9Vkvhgn0VUew=",
         "owner": "holochain",
         "repo": "holochain",
-        "rev": "05c83541777edc70d1add91242be4040e1ab880a",
+        "rev": "9ed45a1496edc1702712e9191681c9b41eab6b41",
         "type": "github"
       },
       "original": {
@@ -660,11 +660,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1720602476,
-        "narHash": "sha256-FhLeb/T4nI9HMD9v3hOtz6Xcu1AuRhdhpwSeNf5igds=",
+        "lastModified": 1721334608,
+        "narHash": "sha256-L1nSTJ5lCOmxUv5WdvgoSvfWUpiLzzqWnvFX7LUVDkU=",
         "owner": "holochain",
         "repo": "holochain",
-        "rev": "61c6e9e396f4c29f2595454b9d0bc723df644ad9",
+        "rev": "786a076b36d98289d4fa18a78b370d9f965bd089",
         "type": "github"
       },
       "original": {
@@ -798,14 +798,14 @@
         "lastModified": 1717431387,
         "narHash": "sha256-+VvWwBmxcgePV1L6kU2mSkg3emMiMgpdQnCqvQJkRPk=",
         "owner": "holochain",
-        "repo": "launcher",
+        "repo": "hc-launch",
         "rev": "9d9cab5e6b57e1c278113921ff203e515c8bbd2e",
         "type": "github"
       },
       "original": {
         "owner": "holochain",
         "ref": "holochain-0.3",
-        "repo": "launcher",
+        "repo": "hc-launch",
         "type": "github"
       }
     },
@@ -993,7 +993,7 @@
       },
       "locked": {
         "lastModified": 0,
-        "narHash": "sha256-cgT5q9Scw0nMmQn2wz+Wt48sW8GiRkILshI5UiKrws4=",
+        "narHash": "sha256-4oiEzDna8/skjP6nIvNN/syGms/eELimqKlb9aERuCc=",
         "path": "../..",
         "type": "path"
       },
@@ -1154,11 +1154,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1720318855,
-        "narHash": "sha256-w3CCVK9LJ5aznXGkO1IyAlbvMNJfyA+dBF7Z1Zwx1LA=",
+        "lastModified": 1720923816,
+        "narHash": "sha256-GrDL1nFYZrB/+Ah1hNoaNFfduB1agpfqL9QyEl12UOU=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "3eed08a074cd2000884a69d448d70da2843f7103",
+        "rev": "fb8c8be0313f0e6385b3d70151a04ea1d71e4b68",
         "type": "github"
       },
       "original": {
@@ -1187,11 +1187,11 @@
     "scaffolding_2": {
       "flake": false,
       "locked": {
-        "lastModified": 1718803517,
-        "narHash": "sha256-TXefe4AJxnfcXDQa9V/rM1ieWybi043pTUI1td4xfzM=",
+        "lastModified": 1721322247,
+        "narHash": "sha256-HtYc28vwS2+YzgE5ZHq+U9vg0W1/mvFblGkLUhMx5wA=",
         "owner": "holochain",
         "repo": "scaffolding",
-        "rev": "ea8dfd8ed4778184338edd3549711f94e70f780e",
+        "rev": "fa5f502eed7fe4438105e0cca6c22f8eed999c52",
         "type": "github"
       },
       "original": {
@@ -1204,11 +1204,11 @@
     "scaffolding_3": {
       "flake": false,
       "locked": {
-        "lastModified": 1720720840,
-        "narHash": "sha256-ffPtG23Y35/SZJItZ664haei2JOoskmOUvXmmk+A+mI=",
+        "lastModified": 1721322247,
+        "narHash": "sha256-HtYc28vwS2+YzgE5ZHq+U9vg0W1/mvFblGkLUhMx5wA=",
         "owner": "holochain",
         "repo": "scaffolding",
-        "rev": "a0cb33880fec6d1a1ad6e7f584ca2642409f1d4e",
+        "rev": "fa5f502eed7fe4438105e0cca6c22f8eed999c52",
         "type": "github"
       },
       "original": {
@@ -1280,11 +1280,11 @@
       },
       "locked": {
         "dir": "versions/0_3",
-        "lastModified": 1720602476,
-        "narHash": "sha256-FhLeb/T4nI9HMD9v3hOtz6Xcu1AuRhdhpwSeNf5igds=",
+        "lastModified": 1721334608,
+        "narHash": "sha256-L1nSTJ5lCOmxUv5WdvgoSvfWUpiLzzqWnvFX7LUVDkU=",
         "owner": "holochain",
         "repo": "holochain",
-        "rev": "61c6e9e396f4c29f2595454b9d0bc723df644ad9",
+        "rev": "786a076b36d98289d4fa18a78b370d9f965bd089",
         "type": "github"
       },
       "original": {
@@ -1303,11 +1303,11 @@
       },
       "locked": {
         "dir": "versions/0_3",
-        "lastModified": 1721208140,
-        "narHash": "sha256-e3p0PG/esuzIFanq4RfYyfI2cfOapoHmqWo4Z+9HcBQ=",
+        "lastModified": 1721389195,
+        "narHash": "sha256-xeMjtS0w9iPGAnLqsrkg3PG4kqzQ8ud9Vkvhgn0VUew=",
         "owner": "holochain",
         "repo": "holochain",
-        "rev": "05c83541777edc70d1add91242be4040e1ab880a",
+        "rev": "9ed45a1496edc1702712e9191681c9b41eab6b41",
         "type": "github"
       },
       "original": {

--- a/examples/end-user-happ/package.json
+++ b/examples/end-user-happ/package.json
@@ -14,7 +14,7 @@
     "local-services": "hc run-local-services --bootstrap-interface $INTERNAL_IP --bootstrap-port $BOOTSTRAP_PORT --signal-interfaces $INTERNAL_IP --signal-port $SIGNAL_PORT",
     "build:happ": "npm run build:zomes && hc app pack workdir --recursive",
     "build:webhapp": "npm run build:zomes && npm run package -w ui && hc web-app pack workdir --recursive",
-    "build:zomes": "CARGO_TARGET_DIR=target cargo build --release --target wasm32-unknown-unknown --workspace --exclude example",
+    "build:zomes": "CARGO_TARGET_DIR=target cargo build --release --target wasm32-unknown-unknown --workspace --exclude example-end-user-happ",
     "tauri": "tauri"
   },
   "dependencies": {

--- a/examples/end-user-happ/src-tauri/Cargo.toml
+++ b/examples/end-user-happ/src-tauri/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "example"
+name = "example-end-user-happ"
 version = "0.0.0"
 description = "A Tauri App"
 authors = ["you"]

--- a/examples/end-user-happ/src-tauri/src/lib.rs
+++ b/examples/end-user-happ/src-tauri/src/lib.rs
@@ -62,13 +62,26 @@ fn signal_url() -> Url2 {
 
 fn holochain_dir() -> PathBuf {
     if tauri::is_dev() {
-        let tmp_dir =
-            tempdir::TempDir::new("example-forum").expect("Could not create temporary directory");
+        #[cfg(target_os = "android")]
+        {
+            app_dirs2::app_root(
+                app_dirs2::AppDataType::UserCache,
+                &app_dirs2::AppInfo {
+                    name: "studio.darksoil.p2pshipyard",
+                    author: "darksoil.studio",
+                },
+            ).expect("Could not get the UserCache directory")
+        }
+        #[cfg(not(target_os = "android"))]
+        {
+            let tmp_dir =
+                tempdir::TempDir::new("example-forum").expect("Could not create temporary directory");
 
-        // Convert `tmp_dir` into a `Path`, destroying the `TempDir`
-        // without deleting the directory.
-        let tmp_path = tmp_dir.into_path();
-        tmp_path
+            // Convert `tmp_dir` into a `Path`, destroying the `TempDir`
+            // without deleting the directory.
+            let tmp_path = tmp_dir.into_path();
+            tmp_path
+        }
     } else {
         app_dirs2::app_root(
             app_dirs2::AppDataType::UserData,

--- a/examples/holochain-runtime/src-tauri/src/lib.rs
+++ b/examples/holochain-runtime/src-tauri/src/lib.rs
@@ -71,13 +71,26 @@ fn signal_url() -> Url2 {
 
 fn holochain_dir() -> PathBuf {
     if tauri::is_dev() {
-        let tmp_dir =
-            tempdir::TempDir::new("launcher").expect("Could not create temporary directory");
+        #[cfg(target_os = "android")]
+        {
+            app_dirs2::app_root(
+                app_dirs2::AppDataType::UserCache,
+                &app_dirs2::AppInfo {
+                    name: "launcher",
+                    author: std::env!("CARGO_PKG_AUTHORS"),
+                },
+            ).expect("Could not get the UserCache directory")
+        }
+        #[cfg(not(target_os = "android"))]
+        {
+            let tmp_dir =
+                tempdir::TempDir::new("launcher").expect("Could not create temporary directory");
 
-        // Convert `tmp_dir` into a `Path`, destroying the `TempDir`
-        // without deleting the directory.
-        let tmp_path = tmp_dir.into_path();
-        tmp_path
+            // Convert `tmp_dir` into a `Path`, destroying the `TempDir`
+            // without deleting the directory.
+            let tmp_path = tmp_dir.into_path();
+            tmp_path
+        }
     } else {
         app_dirs2::app_root(
             app_dirs2::AppDataType::UserData,

--- a/flake.lock
+++ b/flake.lock
@@ -476,11 +476,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1721334608,
-        "narHash": "sha256-L1nSTJ5lCOmxUv5WdvgoSvfWUpiLzzqWnvFX7LUVDkU=",
+        "lastModified": 1721389195,
+        "narHash": "sha256-xeMjtS0w9iPGAnLqsrkg3PG4kqzQ8ud9Vkvhgn0VUew=",
         "owner": "holochain",
         "repo": "holochain",
-        "rev": "786a076b36d98289d4fa18a78b370d9f965bd089",
+        "rev": "9ed45a1496edc1702712e9191681c9b41eab6b41",
         "type": "github"
       },
       "original": {
@@ -563,14 +563,14 @@
         "lastModified": 1717431387,
         "narHash": "sha256-+VvWwBmxcgePV1L6kU2mSkg3emMiMgpdQnCqvQJkRPk=",
         "owner": "holochain",
-        "repo": "launcher",
+        "repo": "hc-launch",
         "rev": "9d9cab5e6b57e1c278113921ff203e515c8bbd2e",
         "type": "github"
       },
       "original": {
         "owner": "holochain",
         "ref": "holochain-0.3",
-        "repo": "launcher",
+        "repo": "hc-launch",
         "type": "github"
       }
     },
@@ -901,11 +901,11 @@
       },
       "locked": {
         "dir": "versions/0_3",
-        "lastModified": 1721334608,
-        "narHash": "sha256-L1nSTJ5lCOmxUv5WdvgoSvfWUpiLzzqWnvFX7LUVDkU=",
+        "lastModified": 1721389195,
+        "narHash": "sha256-xeMjtS0w9iPGAnLqsrkg3PG4kqzQ8ud9Vkvhgn0VUew=",
         "owner": "holochain",
         "repo": "holochain",
-        "rev": "786a076b36d98289d4fa18a78b370d9f965bd089",
+        "rev": "9ed45a1496edc1702712e9191681c9b41eab6b41",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -26,11 +26,11 @@
     "cargo-chef": {
       "flake": false,
       "locked": {
-        "lastModified": 1695999026,
-        "narHash": "sha256-UtLoZd7YBRSF9uXStfC3geEFqSqZXFh1rLHaP8hre0Y=",
+        "lastModified": 1716357509,
+        "narHash": "sha256-7iSxwTaJnDLqaFu4ydxkx7ivhDvSQQcXWKawv/e4NHE=",
         "owner": "LukeMathWalker",
         "repo": "cargo-chef",
-        "rev": "6e96ae5cd023b718ae40d608981e50a6e7d7facf",
+        "rev": "b468537839bfc7c23d744b85d7a5090954626550",
         "type": "github"
       },
       "original": {
@@ -43,11 +43,11 @@
     "cargo-chef_2": {
       "flake": false,
       "locked": {
-        "lastModified": 1695999026,
-        "narHash": "sha256-UtLoZd7YBRSF9uXStfC3geEFqSqZXFh1rLHaP8hre0Y=",
+        "lastModified": 1716357509,
+        "narHash": "sha256-7iSxwTaJnDLqaFu4ydxkx7ivhDvSQQcXWKawv/e4NHE=",
         "owner": "LukeMathWalker",
         "repo": "cargo-chef",
-        "rev": "6e96ae5cd023b718ae40d608981e50a6e7d7facf",
+        "rev": "b468537839bfc7c23d744b85d7a5090954626550",
         "type": "github"
       },
       "original": {
@@ -119,11 +119,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1707363936,
-        "narHash": "sha256-QbqyvGFYt84QNOQLOOTWplZZkzkyDhYrAl/N/9H0vFM=",
+        "lastModified": 1721322122,
+        "narHash": "sha256-a0G1NvyXGzdwgu6e1HQpmK5R5yLsfxeBe07nNDyYd+g=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "9107434eda6991e9388ad87b815dafa337446d16",
+        "rev": "8a68b987c476a33e90f203f0927614a75c3f47ea",
         "type": "github"
       },
       "original": {
@@ -140,11 +140,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1707363936,
-        "narHash": "sha256-QbqyvGFYt84QNOQLOOTWplZZkzkyDhYrAl/N/9H0vFM=",
+        "lastModified": 1721322122,
+        "narHash": "sha256-a0G1NvyXGzdwgu6e1HQpmK5R5yLsfxeBe07nNDyYd+g=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "9107434eda6991e9388ad87b815dafa337446d16",
+        "rev": "8a68b987c476a33e90f203f0927614a75c3f47ea",
         "type": "github"
       },
       "original": {
@@ -156,11 +156,11 @@
     "crate2nix": {
       "flake": false,
       "locked": {
-        "lastModified": 1706909251,
-        "narHash": "sha256-T7G9Uhh77P0kKri/u+Mwa/4YnXwdPsJSwYCiJCCW+fs=",
+        "lastModified": 1719760654,
+        "narHash": "sha256-L3VIJ9182wsYJqP27xO5qiWwfK+a00x0JHiy8ns3NQE=",
         "owner": "kolloch",
         "repo": "crate2nix",
-        "rev": "15656bb6cb15f55ee3344bf4362e6489feb93db6",
+        "rev": "a6ca1e58132bab26fc08572f22a34bbb86f4d91d",
         "type": "github"
       },
       "original": {
@@ -172,11 +172,11 @@
     "crate2nix_2": {
       "flake": false,
       "locked": {
-        "lastModified": 1706909251,
-        "narHash": "sha256-T7G9Uhh77P0kKri/u+Mwa/4YnXwdPsJSwYCiJCCW+fs=",
+        "lastModified": 1719760654,
+        "narHash": "sha256-L3VIJ9182wsYJqP27xO5qiWwfK+a00x0JHiy8ns3NQE=",
         "owner": "kolloch",
         "repo": "crate2nix",
-        "rev": "15656bb6cb15f55ee3344bf4362e6489feb93db6",
+        "rev": "a6ca1e58132bab26fc08572f22a34bbb86f4d91d",
         "type": "github"
       },
       "original": {
@@ -276,11 +276,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1706830856,
-        "narHash": "sha256-a0NYyp+h9hlb7ddVz4LUn1vT/PLwqfrWYcHMvFB1xYg=",
+        "lastModified": 1719994518,
+        "narHash": "sha256-pQMhCCHyQGRzdfAkdJ4cIWiw+JNuWsTX7f0ZYSyz0VY=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "b253292d9c0a5ead9bc98c4e9a26c6312e27d69f",
+        "rev": "9227223f6d922fee3c7b190b2cc238a99527bbb7",
         "type": "github"
       },
       "original": {
@@ -293,11 +293,11 @@
         "nixpkgs-lib": "nixpkgs-lib_2"
       },
       "locked": {
-        "lastModified": 1706830856,
-        "narHash": "sha256-a0NYyp+h9hlb7ddVz4LUn1vT/PLwqfrWYcHMvFB1xYg=",
+        "lastModified": 1719994518,
+        "narHash": "sha256-pQMhCCHyQGRzdfAkdJ4cIWiw+JNuWsTX7f0ZYSyz0VY=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "b253292d9c0a5ead9bc98c4e9a26c6312e27d69f",
+        "rev": "9227223f6d922fee3c7b190b2cc238a99527bbb7",
         "type": "github"
       },
       "original": {
@@ -358,11 +358,11 @@
         "versions": "versions"
       },
       "locked": {
-        "lastModified": 1721334614,
-        "narHash": "sha256-it35pISG3CET1w664PW1gMaxisSuH1/hN4znOfgjn5A=",
+        "lastModified": 1721404544,
+        "narHash": "sha256-NLfWhXkL9mIg58IXoI4WwpV3z1e1lmyUqXuOWlS9BIA=",
         "owner": "holochain-open-dev",
         "repo": "infrastructure",
-        "rev": "24ec261f2379370adf0f80feb3a5e2a33f827a6a",
+        "rev": "afc1fa6492ae1c2e9056da1808f1d8cd877a65d8",
         "type": "github"
       },
       "original": {
@@ -411,11 +411,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1720411619,
-        "narHash": "sha256-r31H9LhRJ402c7ailc1e2Bq8yyftfxMzC9gmpdNRQNc=",
+        "lastModified": 1721403618,
+        "narHash": "sha256-SO9MOHuuuQE5PXnCngwbWB0M47QH8rN7GHWVUWnHx80=",
         "owner": "holochain",
         "repo": "holochain",
-        "rev": "cfbc93e105bd309fdbaa0db4a5da485f3cb5ffcc",
+        "rev": "cfacdd7dace3b78b47daecd69e7d3249d154f1d6",
         "type": "github"
       },
       "original": {
@@ -476,11 +476,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1721389195,
-        "narHash": "sha256-xeMjtS0w9iPGAnLqsrkg3PG4kqzQ8ud9Vkvhgn0VUew=",
+        "lastModified": 1721403618,
+        "narHash": "sha256-SO9MOHuuuQE5PXnCngwbWB0M47QH8rN7GHWVUWnHx80=",
         "owner": "holochain",
         "repo": "holochain",
-        "rev": "9ed45a1496edc1702712e9191681c9b41eab6b41",
+        "rev": "cfacdd7dace3b78b47daecd69e7d3249d154f1d6",
         "type": "github"
       },
       "original": {
@@ -546,14 +546,14 @@
         "lastModified": 1717431387,
         "narHash": "sha256-+VvWwBmxcgePV1L6kU2mSkg3emMiMgpdQnCqvQJkRPk=",
         "owner": "holochain",
-        "repo": "launcher",
+        "repo": "hc-launch",
         "rev": "9d9cab5e6b57e1c278113921ff203e515c8bbd2e",
         "type": "github"
       },
       "original": {
         "owner": "holochain",
         "ref": "holochain-0.3",
-        "repo": "launcher",
+        "repo": "hc-launch",
         "type": "github"
       }
     },
@@ -576,11 +576,11 @@
     },
     "nix-filter": {
       "locked": {
-        "lastModified": 1705332318,
-        "narHash": "sha256-kcw1yFeJe9N4PjQji9ZeX47jg0p9A0DuU4djKvg1a7I=",
+        "lastModified": 1710156097,
+        "narHash": "sha256-1Wvk8UP7PXdf8bCCaEoMnOT1qe5/Duqgj+rL8sRQsSM=",
         "owner": "numtide",
         "repo": "nix-filter",
-        "rev": "3449dc925982ad46246cfc36469baf66e1b64f17",
+        "rev": "3342559a24e85fc164b295c3444e8a139924675b",
         "type": "github"
       },
       "original": {
@@ -591,11 +591,11 @@
     },
     "nix-filter_2": {
       "locked": {
-        "lastModified": 1705332318,
-        "narHash": "sha256-kcw1yFeJe9N4PjQji9ZeX47jg0p9A0DuU4djKvg1a7I=",
+        "lastModified": 1710156097,
+        "narHash": "sha256-1Wvk8UP7PXdf8bCCaEoMnOT1qe5/Duqgj+rL8sRQsSM=",
         "owner": "numtide",
         "repo": "nix-filter",
-        "rev": "3449dc925982ad46246cfc36469baf66e1b64f17",
+        "rev": "3342559a24e85fc164b295c3444e8a139924675b",
         "type": "github"
       },
       "original": {
@@ -622,47 +622,35 @@
     },
     "nixpkgs-lib": {
       "locked": {
-        "dir": "lib",
-        "lastModified": 1706550542,
-        "narHash": "sha256-UcsnCG6wx++23yeER4Hg18CXWbgNpqNXcHIo5/1Y+hc=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "97b17f32362e475016f942bbdfda4a4a72a8a652",
-        "type": "github"
+        "lastModified": 1719876945,
+        "narHash": "sha256-Fm2rDDs86sHy0/1jxTOKB1118Q0O3Uc7EC0iXvXKpbI=",
+        "type": "tarball",
+        "url": "https://github.com/NixOS/nixpkgs/archive/5daf0514482af3f97abaefc78a6606365c9108e2.tar.gz"
       },
       "original": {
-        "dir": "lib",
-        "owner": "NixOS",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
+        "type": "tarball",
+        "url": "https://github.com/NixOS/nixpkgs/archive/5daf0514482af3f97abaefc78a6606365c9108e2.tar.gz"
       }
     },
     "nixpkgs-lib_2": {
       "locked": {
-        "dir": "lib",
-        "lastModified": 1706550542,
-        "narHash": "sha256-UcsnCG6wx++23yeER4Hg18CXWbgNpqNXcHIo5/1Y+hc=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "97b17f32362e475016f942bbdfda4a4a72a8a652",
-        "type": "github"
+        "lastModified": 1719876945,
+        "narHash": "sha256-Fm2rDDs86sHy0/1jxTOKB1118Q0O3Uc7EC0iXvXKpbI=",
+        "type": "tarball",
+        "url": "https://github.com/NixOS/nixpkgs/archive/5daf0514482af3f97abaefc78a6606365c9108e2.tar.gz"
       },
       "original": {
-        "dir": "lib",
-        "owner": "NixOS",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
+        "type": "tarball",
+        "url": "https://github.com/NixOS/nixpkgs/archive/5daf0514482af3f97abaefc78a6606365c9108e2.tar.gz"
       }
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1716293225,
-        "narHash": "sha256-pU9ViBVE3XYb70xZx+jK6SEVphvt7xMTbm6yDIF4xPs=",
+        "lastModified": 1721138476,
+        "narHash": "sha256-+W5eZOhhemLQxelojLxETfbFbc19NWawsXBlapYpqIA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "3eaeaeb6b1e08a016380c279f8846e0bd8808916",
+        "rev": "ad0b5eed1b6031efaed382844806550c3dcb4206",
         "type": "github"
       },
       "original": {
@@ -673,11 +661,11 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1716293225,
-        "narHash": "sha256-pU9ViBVE3XYb70xZx+jK6SEVphvt7xMTbm6yDIF4xPs=",
+        "lastModified": 1721138476,
+        "narHash": "sha256-+W5eZOhhemLQxelojLxETfbFbc19NWawsXBlapYpqIA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "3eaeaeb6b1e08a016380c279f8846e0bd8808916",
+        "rev": "ad0b5eed1b6031efaed382844806550c3dcb4206",
         "type": "github"
       },
       "original": {
@@ -689,11 +677,11 @@
     "pre-commit-hooks-nix": {
       "flake": false,
       "locked": {
-        "lastModified": 1707297608,
-        "narHash": "sha256-ADjo/5VySGlvtCW3qR+vdFF4xM9kJFlRDqcC9ZGI8EA=",
+        "lastModified": 1721042469,
+        "narHash": "sha256-6FPUl7HVtvRHCCBQne7Ylp4p+dpP3P/OYuzjztZ4s70=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "0db2e67ee49910adfa13010e7f012149660af7f0",
+        "rev": "f451c19376071a90d8c58ab1a953c6e9840527fd",
         "type": "github"
       },
       "original": {
@@ -705,11 +693,11 @@
     "pre-commit-hooks-nix_2": {
       "flake": false,
       "locked": {
-        "lastModified": 1707297608,
-        "narHash": "sha256-ADjo/5VySGlvtCW3qR+vdFF4xM9kJFlRDqcC9ZGI8EA=",
+        "lastModified": 1721042469,
+        "narHash": "sha256-6FPUl7HVtvRHCCBQne7Ylp4p+dpP3P/OYuzjztZ4s70=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "0db2e67ee49910adfa13010e7f012149660af7f0",
+        "rev": "f451c19376071a90d8c58ab1a953c6e9840527fd",
         "type": "github"
       },
       "original": {
@@ -771,11 +759,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1720318855,
-        "narHash": "sha256-w3CCVK9LJ5aznXGkO1IyAlbvMNJfyA+dBF7Z1Zwx1LA=",
+        "lastModified": 1721355572,
+        "narHash": "sha256-I4TQ2guV9jTmZsXeWt5HMojcaqNZHII4zu0xIKZEovM=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "3eed08a074cd2000884a69d448d70da2843f7103",
+        "rev": "d5bc7b1b21cf937fb8ff108ae006f6776bdb163d",
         "type": "github"
       },
       "original": {
@@ -792,11 +780,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1720923816,
-        "narHash": "sha256-GrDL1nFYZrB/+Ah1hNoaNFfduB1agpfqL9QyEl12UOU=",
+        "lastModified": 1721355572,
+        "narHash": "sha256-I4TQ2guV9jTmZsXeWt5HMojcaqNZHII4zu0xIKZEovM=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "fb8c8be0313f0e6385b3d70151a04ea1d71e4b68",
+        "rev": "d5bc7b1b21cf937fb8ff108ae006f6776bdb163d",
         "type": "github"
       },
       "original": {
@@ -808,11 +796,11 @@
     "scaffolding": {
       "flake": false,
       "locked": {
-        "lastModified": 1718803517,
-        "narHash": "sha256-TXefe4AJxnfcXDQa9V/rM1ieWybi043pTUI1td4xfzM=",
+        "lastModified": 1721322247,
+        "narHash": "sha256-HtYc28vwS2+YzgE5ZHq+U9vg0W1/mvFblGkLUhMx5wA=",
         "owner": "holochain",
         "repo": "scaffolding",
-        "rev": "ea8dfd8ed4778184338edd3549711f94e70f780e",
+        "rev": "fa5f502eed7fe4438105e0cca6c22f8eed999c52",
         "type": "github"
       },
       "original": {
@@ -878,11 +866,11 @@
       },
       "locked": {
         "dir": "versions/0_3",
-        "lastModified": 1720411619,
-        "narHash": "sha256-r31H9LhRJ402c7ailc1e2Bq8yyftfxMzC9gmpdNRQNc=",
+        "lastModified": 1721403618,
+        "narHash": "sha256-SO9MOHuuuQE5PXnCngwbWB0M47QH8rN7GHWVUWnHx80=",
         "owner": "holochain",
         "repo": "holochain",
-        "rev": "cfbc93e105bd309fdbaa0db4a5da485f3cb5ffcc",
+        "rev": "cfacdd7dace3b78b47daecd69e7d3249d154f1d6",
         "type": "github"
       },
       "original": {
@@ -901,11 +889,11 @@
       },
       "locked": {
         "dir": "versions/0_3",
-        "lastModified": 1721389195,
-        "narHash": "sha256-xeMjtS0w9iPGAnLqsrkg3PG4kqzQ8ud9Vkvhgn0VUew=",
+        "lastModified": 1721403618,
+        "narHash": "sha256-SO9MOHuuuQE5PXnCngwbWB0M47QH8rN7GHWVUWnHx80=",
         "owner": "holochain",
         "repo": "holochain",
-        "rev": "9ed45a1496edc1702712e9191681c9b41eab6b41",
+        "rev": "cfacdd7dace3b78b47daecd69e7d3249d154f1d6",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -476,11 +476,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1721403618,
-        "narHash": "sha256-SO9MOHuuuQE5PXnCngwbWB0M47QH8rN7GHWVUWnHx80=",
+        "lastModified": 1721413603,
+        "narHash": "sha256-LrSUS7RQ4NiWTlaZ3QR8gdcOUdT+vfPcZVkOfG73tPM=",
         "owner": "holochain",
         "repo": "holochain",
-        "rev": "cfacdd7dace3b78b47daecd69e7d3249d154f1d6",
+        "rev": "d36925c84609a36303c3b6439d03d07c46e71078",
         "type": "github"
       },
       "original": {
@@ -889,11 +889,11 @@
       },
       "locked": {
         "dir": "versions/0_3",
-        "lastModified": 1721403618,
-        "narHash": "sha256-SO9MOHuuuQE5PXnCngwbWB0M47QH8rN7GHWVUWnHx80=",
+        "lastModified": 1721413603,
+        "narHash": "sha256-LrSUS7RQ4NiWTlaZ3QR8gdcOUdT+vfPcZVkOfG73tPM=",
         "owner": "holochain",
         "repo": "holochain",
-        "rev": "cfacdd7dace3b78b47daecd69e7d3249d154f1d6",
+        "rev": "d36925c84609a36303c3b6439d03d07c46e71078",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
This superseeds https://github.com/darksoil-studio/p2p-shipyard/pull/14 in doing the same thing but only for the Android platform. This avoids the directory collisions when two instances of the same app are run while developing in desktop platforms.