### PR TITLE
build: reduce size of release bundle with rust compiler optimizations

### DIFF
--- a/crates/scaffold-holochain-runtime/templates/holochain-runtime/src-tauri/Cargo.toml.hbs
+++ b/crates/scaffold-holochain-runtime/templates/holochain-runtime/src-tauri/Cargo.toml.hbs
@@ -30,3 +30,7 @@ app_dirs2 = "2.5.5"
 tempdir = "0.3.7"
 anyhow = "1"
 uuid = "1"
+
+[profile.release]
+opt-level = "z"
+lto = true

--- a/crates/scaffold-tauri-happ/templates/end-user-happ/src-tauri/Cargo.toml.hbs
+++ b/crates/scaffold-tauri-happ/templates/end-user-happ/src-tauri/Cargo.toml.hbs
@@ -32,3 +32,7 @@ app_dirs2 = "2.5.5"
 tempdir = "0.3.7"
 anyhow = "1"
 uuid = "1"
+
+[profile.release]
+opt-level = "z"
+lto = true


### PR DESCRIPTION
Currently a basic holochain app apk (built for 5 cpu targets) is ~500MB. A basic tauri app apk is ~50MB.

I think most of the bundle size is from having holochain as a dep. With rust compiler optimizations for size we can cut that in half.