### PR TITLE
Build/tauri version pinning

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -96,9 +96,9 @@ dependencies = [
 
 [[package]]
 name = "aitia"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df16ceb7a48cd5b32ff6f5229ea89fad2e61b5f702a603d1ee4a2f2d2d3c6b3b"
+checksum = "0c8d0d87e1228df0569cc160bb52542afaa7def9fcd248d1405febb400619126"
 dependencies = [
  "anyhow",
  "derive_more",
@@ -2286,9 +2286,9 @@ checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "fixt"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b00a24e34fdd8f793f4eb4e507c8dde88f6c560c19ad337c2fb1f82bb11613cd"
+checksum = "ed8befecee7e4e63c317ab8acbc953c4aceb55e12a3a28b51b40dbb627562ae6"
 dependencies = [
  "holochain_serialized_bytes",
  "lazy_static",
@@ -3078,9 +3078,9 @@ dependencies = [
 
 [[package]]
 name = "hc_sleuth"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89308367812f00b6de1b0682129d23e2fcc3a6d1ae7877d68744c4a63957a627"
+checksum = "60d2cec326f6b4fd869e86d79a698589a7e0898b16d7b2675f2733770d28acad"
 dependencies = [
  "aitia",
  "anyhow",
@@ -3101,9 +3101,9 @@ dependencies = [
 
 [[package]]
 name = "hdi"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ece9b147d5e9ebc0a1f47a180a31436f4390a060ad46aa325d1fb851321ec3c7"
+checksum = "f6a494d33e1082b380b8163ace83d53ca39ca053d0f45f6997d13a8fca008a35"
 dependencies = [
  "getrandom 0.2.15",
  "hdk_derive",
@@ -3119,9 +3119,9 @@ dependencies = [
 
 [[package]]
 name = "hdk"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01ba518e916e7eb29cf4a3b4c0d853fefab76bffc19939f8e0e5925581c67da7"
+checksum = "26d6fef9a03facd811accc5a1bb1e22a577e4875190b53337ff01b4746463c78"
 dependencies = [
  "getrandom 0.2.15",
  "hdi",
@@ -3139,9 +3139,9 @@ dependencies = [
 
 [[package]]
 name = "hdk_derive"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93b26f45db67e2619836cd70a880bcf46d40ef844cd838d99ef6008e0f84e86c"
+checksum = "4d00472129b62df85a0c853e7ce8cbd4a868e8cf2a30896c470176500d887795"
 dependencies = [
  "darling 0.14.4",
  "heck 0.5.0",
@@ -3242,9 +3242,9 @@ dependencies = [
 
 [[package]]
 name = "holo_hash"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acfa694a0138aafda54ce76033168cf182158b7628f7e70b12af0ea0ad20d896"
+checksum = "f68f60591ed381388f46c59351a6e2c3d77cb1409a94200dbfd423a6bb8a3622"
 dependencies = [
  "base64 0.22.1",
  "blake2b_simd",
@@ -3265,9 +3265,9 @@ dependencies = [
 
 [[package]]
 name = "holochain"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1eb75811baa0598d13a0b01d0b0becc54e26efda9effc20a03e9557367e3d0c"
+checksum = "94681f4ca30845b27f44cb751a8db6a0cef266dc45c8a44ba0c3af95550403d4"
 dependencies = [
  "aitia",
  "anyhow",
@@ -3359,9 +3359,9 @@ dependencies = [
 
 [[package]]
 name = "holochain_cascade"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3119db52d092b333947dacf9aec95d99a7eadc8eda1a2bc97730e77bafe034ae"
+checksum = "30641ba03a9abb8d7793690f07d3b626ddf4c963d1fb1ad6ab3be213cb6d76bf"
 dependencies = [
  "async-trait",
  "fixt",
@@ -3411,9 +3411,9 @@ dependencies = [
 
 [[package]]
 name = "holochain_conductor_api"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "172baa045723827a37d066b2c564e231689abf4570fe512f07778dc0c78d7c8a"
+checksum = "2beb2ef85e53cb2567ad6cd555bb0566394b34ffbc4b090715bbebbb167d20cc"
 dependencies = [
  "derive_more",
  "holo_hash",
@@ -3434,9 +3434,9 @@ dependencies = [
 
 [[package]]
 name = "holochain_conductor_services"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "734cf4cd51642e97e3a7b4085e969a09aa6f6236b3a72b964a8df30b71704793"
+checksum = "dfea6be130982205a5421648245a678d429724aaeaf1a61157f3652ccc823355"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3450,9 +3450,9 @@ dependencies = [
 
 [[package]]
 name = "holochain_integrity_types"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc3c84cd0ee02fa15e037df4fd81c170cb956792732823416c61b0f4e3d2e177"
+checksum = "dbb39eaaff334d30de7c7ff547e9f68490098fe379e747852367e508ac485cb3"
 dependencies = [
  "derive_builder 0.20.1",
  "holo_hash",
@@ -3469,9 +3469,9 @@ dependencies = [
 
 [[package]]
 name = "holochain_keystore"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "571f76a5f5d229ce854f9f7757f42db4767ed3248ac886396776450970300979"
+checksum = "d15bc60dc779fbfd3a99dc3e37f2c5e9eb9c10d3109f70237d6b3d5f69c1c82b"
 dependencies = [
  "base64 0.22.1",
  "derive_more",
@@ -3498,9 +3498,9 @@ dependencies = [
 
 [[package]]
 name = "holochain_metrics"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6811d3b83553ef9e3369b79e67955d978af0b7503d2393805c220342bf3b985"
+checksum = "a74d7492154a24290d96edfd7548dd895d6f66d9b80a2b9f9a256ef7a8e9b37f"
 dependencies = [
  "influxive",
  "opentelemetry_api",
@@ -3509,9 +3509,9 @@ dependencies = [
 
 [[package]]
 name = "holochain_nonce"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbbb63a7658f55a0640a04ad675d7dc6979b7eb7f0a889882efa6e9ac95fd606"
+checksum = "7342ca1e823909779cba6f7c0338c82f150957a10ef9931befaf7d75454c6bb7"
 dependencies = [
  "getrandom 0.2.15",
  "holochain_secure_primitive",
@@ -3520,9 +3520,9 @@ dependencies = [
 
 [[package]]
 name = "holochain_p2p"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bfde1589d00397861464f9234b8877b2e821f8f5fa6c0217070a0fee77e7bf7"
+checksum = "e0c0bbefdccba24a52dc3d25355f7280cf4a15c21bf5bb592b7d5acadaffafb5"
 dependencies = [
  "aitia",
  "async-trait",
@@ -3566,9 +3566,9 @@ dependencies = [
 
 [[package]]
 name = "holochain_secure_primitive"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2495193fe4700ccd3fda02acc7f982890938b28deb264c9212df3868efd9e0e"
+checksum = "023dd96581cb629abc8089a6a583ad4fd47336c2600f8f1bad0035229b35e260"
 dependencies = [
  "paste",
  "serde",
@@ -3602,9 +3602,9 @@ dependencies = [
 
 [[package]]
 name = "holochain_sqlite"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e8b43b7ffd327ded81ff3b5851bbe24757d2822fe288d5b018516ce371a86a4"
+checksum = "f986b3437bf22037f9372ac9db9e74e571bd4b7957b0a26cc4a339de3866f8af"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3645,9 +3645,9 @@ dependencies = [
 
 [[package]]
 name = "holochain_state"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd4bbe822026fb0afda545a22b4e1aa98b7470072806b47af71bafc716f6ea39"
+checksum = "6ef99f9cfb8a0821b921d6be151797cb6fcec9ad5e27120f6d7b8b65a6d2c7ec"
 dependencies = [
  "aitia",
  "async-recursion",
@@ -3677,9 +3677,9 @@ dependencies = [
 
 [[package]]
 name = "holochain_state_types"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f876726313c8373f2c0934eb1f9fd1cff99f94c51281898779daa1ba22ba4a4"
+checksum = "7ea98b0b2e8f51a83d617e194d1a73271e348a52b2f3f371cf860ec9e05e8746"
 dependencies = [
  "holo_hash",
  "holochain_integrity_types",
@@ -3688,9 +3688,9 @@ dependencies = [
 
 [[package]]
 name = "holochain_trace"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a1fa6e79b0774ef51faf34213abd620dc80caa9da0e4f3ff4e64b85be7a9416"
+checksum = "91445161ac030d586669207807cb165e6943e7e56aeda485476fc020ffa99f62"
 dependencies = [
  "chrono",
  "derive_more",
@@ -3706,9 +3706,9 @@ dependencies = [
 
 [[package]]
 name = "holochain_types"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cd76009a50e6155adc650741b8188188abe4d3daff8666864ef808d314d9e6d"
+checksum = "1f5a24d9090e7288d7abba810c87c73a63b6f940cee264c4c98a0951e85d047c"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3755,9 +3755,9 @@ dependencies = [
 
 [[package]]
 name = "holochain_util"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df91c909ed1bcf3dfc55db8dfa8361dba9c4e518c80f9cd30b5c00a3e9c84c62"
+checksum = "4fa1fbf85e159b07bac3bb9596f9af5ca79e8e31f83c47a70f8517fd945bcd04"
 dependencies = [
  "backtrace",
  "cfg-if 1.0.0",
@@ -3773,9 +3773,9 @@ dependencies = [
 
 [[package]]
 name = "holochain_wasm_test_utils"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1333cd0ba272e3191489e52538a3b787f294ca81ccf3b6e0d3839be5cf3fca4"
+checksum = "6a98d7627be51e9f40447773f5c843c14c47187436ea832ff95212385320b0ea"
 dependencies = [
  "holochain_types",
  "holochain_util",
@@ -3834,9 +3834,9 @@ dependencies = [
 
 [[package]]
 name = "holochain_websocket"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0e211a00967a0e7796fcd43b28a7109d92d44ff19266cf08a2da40e62e7a33f"
+checksum = "41096273a68c09422a30a744902406a19abdc122899a6b11474dba4e1b35e05e"
 dependencies = [
  "async-trait",
  "futures",
@@ -3851,9 +3851,9 @@ dependencies = [
 
 [[package]]
 name = "holochain_zome_types"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "526a51ed0b962c2579ff57106fe2dd032a9a1cf2e4820f3dc2f2b37a59b0cc66"
+checksum = "9e7cb5c0a7d7162bb3f3fe96e4fb63b31da47a11aa3f3d509e44b78ca4920382"
 dependencies = [
  "derive_builder 0.20.1",
  "derive_more",
@@ -4600,9 +4600,9 @@ dependencies = [
 
 [[package]]
 name = "kitsune_p2p"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "820f8c4b6fe9c5282361ebce22b9b355e3a6f3f0259acf8b585f1d46c503ca12"
+checksum = "d139523575868a1a8ed109556db5a1004ccc5d5a2e6e3bf62f6bad3777c6150c"
 dependencies = [
  "arrayref",
  "base64 0.22.1",
@@ -4644,9 +4644,9 @@ dependencies = [
 
 [[package]]
 name = "kitsune_p2p_bin_data"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5d57481371cae8f3afdc4f8b0791aa04c70afe375c8678ca2bf966637220b6a"
+checksum = "33f6e27475c31b3492ba78dbc0e945798cf00d7489def5e574f1ff26ab7cdffb"
 dependencies = [
  "base64 0.22.1",
  "derive_more",
@@ -4659,9 +4659,9 @@ dependencies = [
 
 [[package]]
 name = "kitsune_p2p_block"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10105ffc84c408d89a39180460fa9adcfcff09dedb511703efdab050fdbfe40c"
+checksum = "9bf0b3a417771c4d5268cb211a2aba64d495091868f990c7e728362aab7c8f6d"
 dependencies = [
  "kitsune_p2p_bin_data",
  "kitsune_p2p_timestamp",
@@ -4670,9 +4670,9 @@ dependencies = [
 
 [[package]]
 name = "kitsune_p2p_bootstrap"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "819b705dd8ef03a47b7d1d5df604cead7be890fcea864d028212252baa8ae649"
+checksum = "82389b98b00346c7f92248fb73825c083720fb729748a6c184e7da938b1c41d0"
 dependencies = [
  "clap 4.5.19",
  "futures",
@@ -4690,9 +4690,9 @@ dependencies = [
 
 [[package]]
 name = "kitsune_p2p_bootstrap_client"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af44ba9ef97b6e00c99c8762d679eaa209e933e1e6fc517ef8df8a8134f1b3f7"
+checksum = "3a1c01931a38d0e09927bcf78040fc97de35491c96be63352c0c4371af9a7e57"
 dependencies = [
  "kitsune_p2p_bin_data",
  "kitsune_p2p_bootstrap",
@@ -4705,9 +4705,9 @@ dependencies = [
 
 [[package]]
 name = "kitsune_p2p_dht"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58e09eb5fefd76459e8417234dff5170dcc40c6bddfe56d84d59d1b1867e4378"
+checksum = "57f1f73203977efe3cc1141a959b07b29d82220f211955f14f72e5731ac8cb05"
 dependencies = [
  "derivative",
  "derive_more",
@@ -4725,9 +4725,9 @@ dependencies = [
 
 [[package]]
 name = "kitsune_p2p_dht_arc"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6be19fb54f5f3adb7ef461d51d073f22f3e7343952a31523d04799bceb695ee2"
+checksum = "b703d57c74b2a3d187ec3bbd2be8cf0f52c8d8e1059f5ba3c0d23218f6504e84"
 dependencies = [
  "derive_more",
  "gcollections",
@@ -4740,9 +4740,9 @@ dependencies = [
 
 [[package]]
 name = "kitsune_p2p_fetch"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbafc5fb36c8940989b6d8c4ea02aec09efc4f195e79d4532b5bdb363bbec1d2"
+checksum = "e6550ea608b633ac295a545c84fb7ff435c263b80a4b16907ab6aace6ac4ae15"
 dependencies = [
  "backon",
  "derive_more",
@@ -4756,9 +4756,9 @@ dependencies = [
 
 [[package]]
 name = "kitsune_p2p_mdns"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17854121a83e6694bd890c869fa7e511449131495c0ad954c13409f2fc8e7b5e"
+checksum = "305236dcbbd2c48d03c29ce430bd8319f7c7e4c64790f97bdb4337238871393b"
 dependencies = [
  "base64 0.22.1",
  "err-derive 0.3.1",
@@ -4771,9 +4771,9 @@ dependencies = [
 
 [[package]]
 name = "kitsune_p2p_proxy"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59c6aa7991351145e7ee372777335851290dbec181d4defa7b266e88778c4c6a"
+checksum = "f571aa38f61733d1e6a41d35cc08f514a5616039363a47ea7e92d4dd958ccbd1"
 dependencies = [
  "base64 0.22.1",
  "derive_more",
@@ -4789,9 +4789,9 @@ dependencies = [
 
 [[package]]
 name = "kitsune_p2p_timestamp"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f0ae9c213de76b54f2a7fcfd1f379b106b45efef1c4365110d7df96a531d69e"
+checksum = "dade104770176570d49fc70d56801f81e0969b440b71f92ed5ea99746da4932f"
 dependencies = [
  "chrono",
  "rusqlite",
@@ -4800,9 +4800,9 @@ dependencies = [
 
 [[package]]
 name = "kitsune_p2p_transport_quic"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcda54a6237011a388f0d4bc2a63eb4011927c08dc805fbb41139414c86f1ca9"
+checksum = "5702ab51e38eccf842e626cfa785f8e6765ac201ed3251b6a6a284d543bd09a0"
 dependencies = [
  "blake2b_simd",
  "futures",
@@ -4816,9 +4816,9 @@ dependencies = [
 
 [[package]]
 name = "kitsune_p2p_types"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5466b1e18532035c7bdb3347362463943ed3c7896e2970ba224896f9a2556540"
+checksum = "46c0cd7db3b403856bcaebc6a781782bb94350e24cfec2d9296a1518310f1a28"
 dependencies = [
  "base64 0.22.1",
  "derive_more",
@@ -5340,9 +5340,9 @@ checksum = "7843ec2de400bcbc6a6328c958dc38e5359da6e93e72e37bc5246bf1ae776389"
 
 [[package]]
 name = "mr_bundle"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2343770ce615ec247e0089a8eaae5731809493a708ac244e187e43a005fb1987"
+checksum = "032b2adeb25720b79d7a18ae93dc53a9719e93e6eb707f12b53898b6b4e3febb"
 dependencies = [
  "derive_more",
  "flate2",

--- a/crates/hc-pilot/Cargo.toml
+++ b/crates/hc-pilot/Cargo.toml
@@ -10,7 +10,7 @@ tauri = "2"
 tauri-plugin-log = "2"
 
 tauri-plugin-holochain = { path = "../tauri-plugin-holochain" }
-holochain_types = "0.3.2"
+holochain_types = "0.3.3"
 holochain_client = "0.5.1"
 
 clap = { version = "4.5.4", features = ["derive"] }

--- a/crates/hc-pilot/Cargo.toml
+++ b/crates/hc-pilot/Cargo.toml
@@ -6,8 +6,8 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-tauri = "2.0.0"
-tauri-plugin-log = "2.0.0"
+tauri = "2"
+tauri-plugin-log = "2"
 
 tauri-plugin-holochain = { path = "../tauri-plugin-holochain" }
 holochain_types = "0.3.2"
@@ -21,5 +21,4 @@ tempdir = "0.3.7"
 lair_keystore = { version = "0.4.5" }
 
 [build-dependencies]
-tauri-build = { version = "2.0.0", default-features = false, features = [
-] }
+tauri-build = { version = "2", default-features = false }

--- a/crates/scaffold-holochain-runtime/templates/holochain-runtime/src-tauri/Cargo.toml.hbs
+++ b/crates/scaffold-holochain-runtime/templates/holochain-runtime/src-tauri/Cargo.toml.hbs
@@ -18,7 +18,7 @@ crate-type = ["staticlib", "cdylib", "rlib"]
 tauri-build = { version = "2.0.0", default-features = false , features = [] }
 
 [dependencies]
-tauri = { version = "2.0.0", features = [] }
+tauri = { version = "2", features = [] }
 tauri-plugin-holochain = { git = "https://github.com/darksoil-studio/p2p-shipyard", branch = "main" }
 holochain_types = { version = "0.3.2" }
 lair_keystore = { version = "0.4.5" }

--- a/crates/scaffold-holochain-runtime/templates/holochain-runtime/src-tauri/Cargo.toml.hbs
+++ b/crates/scaffold-holochain-runtime/templates/holochain-runtime/src-tauri/Cargo.toml.hbs
@@ -20,7 +20,7 @@ tauri-build = { version = "2.0.0", default-features = false , features = [] }
 [dependencies]
 tauri = { version = "2", features = [] }
 tauri-plugin-holochain = { git = "https://github.com/darksoil-studio/p2p-shipyard", branch = "main" }
-holochain_types = { version = "0.3.2" }
+holochain_types = { version = "0.3.3" }
 lair_keystore = { version = "0.4.5" }
 holochain_client = { version = "0.5.1" }
 log = "0.4"

--- a/crates/scaffold-tauri-happ/src/lib.rs
+++ b/crates/scaffold-tauri-happ/src/lib.rs
@@ -496,8 +496,8 @@ members = ["dnas/*/zomes/coordinator/*", "dnas/*/zomes/integrity/*", "src-tauri"
 resolver = "2"
 
 [workspace.dependencies]
-hdi = "0.4.2"
-hdk = "0.3.2"
+hdi = "0.4.3"
+hdk = "0.3.3"
 serde = "1.0"
 
 [workspace.dependencies.posts]
@@ -520,8 +520,8 @@ resolver = "2"
 members = ["dnas/*/zomes/coordinator/*", "dnas/*/zomes/integrity/*"]
 
 [workspace.dependencies]
-hdi = "0.4.2"
-hdk = "0.3.2"
+hdi = "0.4.3"
+hdk = "0.3.3"
 serde = "1.0"
 
 [workspace.dependencies.posts]

--- a/crates/scaffold-tauri-happ/templates/end-user-happ/src-tauri/Cargo.toml.hbs
+++ b/crates/scaffold-tauri-happ/templates/end-user-happ/src-tauri/Cargo.toml.hbs
@@ -18,7 +18,7 @@ crate-type = ["staticlib", "cdylib", "rlib"]
 tauri-build = { version = "2.0.0", default-features = false , features = [] }
 
 [dependencies]
-tauri = { version = "2.0.0", features = [] }
+tauri = { version = "2", features = [] }
 tauri-plugin-holochain = { git = "https://github.com/darksoil-studio/p2p-shipyard", branch = "main" }
 holochain_types = { version = "0.3.2" }
 lair_keystore = { version = "0.4.5" }

--- a/crates/scaffold-tauri-happ/templates/end-user-happ/src-tauri/Cargo.toml.hbs
+++ b/crates/scaffold-tauri-happ/templates/end-user-happ/src-tauri/Cargo.toml.hbs
@@ -20,7 +20,7 @@ tauri-build = { version = "2.0.0", default-features = false , features = [] }
 [dependencies]
 tauri = { version = "2", features = [] }
 tauri-plugin-holochain = { git = "https://github.com/darksoil-studio/p2p-shipyard", branch = "main" }
-holochain_types = { version = "0.3.2" }
+holochain_types = { version = "0.3.3" }
 lair_keystore = { version = "0.4.5" }
 
 holochain_client = { version = "0.5.1" }

--- a/crates/tauri-plugin-holochain/Cargo.toml
+++ b/crates/tauri-plugin-holochain/Cargo.toml
@@ -8,7 +8,7 @@ rust-version = "1.75"
 links = "tauri-plugin-holochain"
 
 [dependencies]
-tauri = { version = "2.0.0", features = [
+tauri = { version = "2", features = [
   "devtools",
   "native-tls-vendored",
 ] }

--- a/crates/tauri-plugin-holochain/Cargo.toml
+++ b/crates/tauri-plugin-holochain/Cargo.toml
@@ -14,16 +14,16 @@ tauri = { version = "2", features = [
 ] }
 
 # Holochain dependencies
-mr_bundle = "0.3.2"
-holochain = "0.3.2"
-holochain_types = "0.3.2"
-holochain_keystore = "0.3.2"
-holochain_conductor_api = "0.3.2"
+mr_bundle = "0.3.3"
+holochain = "0.3.3"
+holochain_types = "0.3.3"
+holochain_keystore = "0.3.3"
+holochain_conductor_api = "0.3.3"
 
 sqlformat = "=0.2.3"
 
-kitsune_p2p_mdns = "0.3.2"
-kitsune_p2p_types = "0.3.2"
+kitsune_p2p_mdns = "0.3.3"
+kitsune_p2p_types = "0.3.3"
 
 tx5-signal-srv = "0.0.14-alpha"
 tx5-signal = "0.0.14-alpha"

--- a/examples/end-user-happ/Cargo.toml
+++ b/examples/end-user-happ/Cargo.toml
@@ -9,8 +9,8 @@ resolver = "2"
 members = ["dnas/*/zomes/coordinator/*", "dnas/*/zomes/integrity/*", "src-tauri"]
 
 [workspace.dependencies]
-hdi = "0.4.2"
-hdk = "0.3.2"
+hdi = "0.4.3"
+hdk = "0.3.3"
 serde = "1.0"
 
 [workspace.dependencies.posts]

--- a/examples/end-user-happ/src-tauri/Cargo.toml
+++ b/examples/end-user-happ/src-tauri/Cargo.toml
@@ -19,7 +19,7 @@ tauri-build = { version = "2.0.0", default-features = false, features = [
 ] }
 
 [dependencies]
-tauri = { version = "2.0.0", features = [] }
+tauri = { version = "2", features = [] }
 tauri-plugin-holochain = { path = "../../../crates/tauri-plugin-holochain" }
 holochain_types = { version = "0.3.2" }
 lair_keystore = { version = "0.4.5" }

--- a/examples/end-user-happ/src-tauri/Cargo.toml
+++ b/examples/end-user-happ/src-tauri/Cargo.toml
@@ -21,7 +21,7 @@ tauri-build = { version = "2.0.0", default-features = false, features = [
 [dependencies]
 tauri = { version = "2", features = [] }
 tauri-plugin-holochain = { path = "../../../crates/tauri-plugin-holochain" }
-holochain_types = { version = "0.3.2" }
+holochain_types = { version = "0.3.3" }
 lair_keystore = { version = "0.4.5" }
 holochain_client = { version = "0.5.1" }
 log = "0.4"

--- a/examples/holochain-runtime/src-tauri/Cargo.toml
+++ b/examples/holochain-runtime/src-tauri/Cargo.toml
@@ -19,7 +19,7 @@ tauri-build = { version = "2.0.0", default-features = false, features = [
 ] }
 
 [dependencies]
-tauri = { version = "2.0.0", features = [] }
+tauri = { version = "2", features = [] }
 tauri-plugin-holochain = { path = "../../../crates/tauri-plugin-holochain" }
 holochain_types = { version = "0.3.2" }
 lair_keystore = { version = "0.4.5" }

--- a/examples/holochain-runtime/src-tauri/Cargo.toml
+++ b/examples/holochain-runtime/src-tauri/Cargo.toml
@@ -21,7 +21,7 @@ tauri-build = { version = "2.0.0", default-features = false, features = [
 [dependencies]
 tauri = { version = "2", features = [] }
 tauri-plugin-holochain = { path = "../../../crates/tauri-plugin-holochain" }
-holochain_types = { version = "0.3.2" }
+holochain_types = { version = "0.3.3" }
 lair_keystore = { version = "0.4.5" }
 holochain_client = { version = "0.5.1" }
 log = "0.4"

--- a/flake.lock
+++ b/flake.lock
@@ -166,11 +166,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1728680157,
-        "narHash": "sha256-4rfZbfkRv0/9gnC6flPPA60r8fuXL92l7xA3y3kCBNo=",
+        "lastModified": 1728680310,
+        "narHash": "sha256-43nvdSVyI5fe6MQjzM00jb7oSCxLmKQclqvYsWCmMTE=",
         "owner": "holochain-open-dev",
         "repo": "infrastructure",
-        "rev": "2f79c1526ee43c689927c4ecee59b6ee2155421d",
+        "rev": "6e49ab461291f6d6dfbb64945cc9210cbf7653e3",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -3,7 +3,7 @@
     "android-nixpkgs": {
       "inputs": {
         "devshell": "devshell",
-        "flake-utils": "flake-utils",
+        "flake-utils": "flake-utils_2",
         "nixpkgs": "nixpkgs"
       },
       "locked": {
@@ -38,11 +38,11 @@
     },
     "crane_2": {
       "locked": {
-        "lastModified": 1725125250,
-        "narHash": "sha256-CB20rDD5eHikF6mMTTJdwPP1qvyoiyyw1RDUzwIaIF8=",
+        "lastModified": 1727974419,
+        "narHash": "sha256-WD0//20h+2/yPGkO88d2nYbb23WMWYvnRyDQ9Dx4UHg=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "96fd12c7100e9e05fa1a0a5bd108525600ce282f",
+        "rev": "37e4f9f0976cb9281cd3f0c70081e5e0ecaee93f",
         "type": "github"
       },
       "original": {
@@ -53,17 +53,18 @@
     },
     "devshell": {
       "inputs": {
+        "flake-utils": "flake-utils",
         "nixpkgs": [
           "android-nixpkgs",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1722113426,
-        "narHash": "sha256-Yo/3loq572A8Su6aY5GP56knpuKYRvM2a1meP9oJZCw=",
+        "lastModified": 1717408969,
+        "narHash": "sha256-Q0OEFqe35fZbbRPPRdrjTUUChKVhhWXz3T9ZSKmaoVY=",
         "owner": "numtide",
         "repo": "devshell",
-        "rev": "67cce7359e4cd3c45296fb4aaf6a19e2a9c757ae",
+        "rev": "1ebbe68d57457c8cae98145410b164b5477761f4",
         "type": "github"
       },
       "original": {
@@ -95,11 +96,11 @@
         "nixpkgs-lib": "nixpkgs-lib_2"
       },
       "locked": {
-        "lastModified": 1725234343,
-        "narHash": "sha256-+ebgonl3NbiKD2UD0x4BszCZQ6sTfL4xioaM49o5B3Y=",
+        "lastModified": 1727826117,
+        "narHash": "sha256-K5ZLCyfO/Zj9mPFldf3iwS6oZStJcU4tSpiXTMYaaL0=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "567b938d64d4b4112ee253b9274472dc3a346eb6",
+        "rev": "3d04084d54bedc3d6b8b736c70ef449225c361b1",
         "type": "github"
       },
       "original": {
@@ -113,11 +114,29 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1726560853,
-        "narHash": "sha256-X6rJYSESBVr3hBoH0WbKE5KvhPU5bloyZ2L4K60/fPQ=",
+        "lastModified": 1701680307,
+        "narHash": "sha256-kAuep2h5ajznlPMD9rnQyffWG8EM/C73lejGofXvdM8=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "c1dfcf08411b08f6b8615f7d8971a2bfa81d5e8a",
+        "rev": "4022d587cbbfd70fe950c1e2083a02621806a725",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_2": {
+      "inputs": {
+        "systems": "systems_2"
+      },
+      "locked": {
+        "lastModified": 1710146030,
+        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
         "type": "github"
       },
       "original": {
@@ -147,11 +166,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1727440365,
-        "narHash": "sha256-XeonUZzVKcl3QDrhE9zP2JuK4LkzSsNIf/p/qKS9PNM=",
+        "lastModified": 1728573856,
+        "narHash": "sha256-XlnTbS45DKtlHjhc3KT2lqlEn86dxEMcmcHobDn69Zc=",
         "owner": "holochain-open-dev",
         "repo": "infrastructure",
-        "rev": "80fae8556cdcc5b8dc155ca41f3786787bcf806a",
+        "rev": "e342ffa8d1304205a0f5a339d00923243a2bd309",
         "type": "github"
       },
       "original": {
@@ -197,11 +216,11 @@
     "hc-scaffold": {
       "flake": false,
       "locked": {
-        "lastModified": 1724073530,
-        "narHash": "sha256-PUM8otA5F5s8ZHxhjupn7R+RZAjh2rueYIFwu3UkK44=",
+        "lastModified": 1727691892,
+        "narHash": "sha256-8dMLmpYp19wZhxlR1uiSeR23nGAOhHnyiZ/5CPwOoAg=",
         "owner": "holochain",
         "repo": "scaffolding",
-        "rev": "8a6d1dab0f1668c2781a46d93a5ad638fcf25598",
+        "rev": "d0290b88ac08e6811d57acb3294a177d107d2528",
         "type": "github"
       },
       "original": {
@@ -214,11 +233,11 @@
     "hc-scaffold_2": {
       "flake": false,
       "locked": {
-        "lastModified": 1724073530,
-        "narHash": "sha256-PUM8otA5F5s8ZHxhjupn7R+RZAjh2rueYIFwu3UkK44=",
+        "lastModified": 1727691892,
+        "narHash": "sha256-8dMLmpYp19wZhxlR1uiSeR23nGAOhHnyiZ/5CPwOoAg=",
         "owner": "holochain",
         "repo": "scaffolding",
-        "rev": "8a6d1dab0f1668c2781a46d93a5ad638fcf25598",
+        "rev": "d0290b88ac08e6811d57acb3294a177d107d2528",
         "type": "github"
       },
       "original": {
@@ -248,16 +267,16 @@
     "holochain_2": {
       "flake": false,
       "locked": {
-        "lastModified": 1722347117,
-        "narHash": "sha256-Jv4DxaVtdbO+fOD4woFoepCCOtRN/HF94xJSwViz3ck=",
+        "lastModified": 1728056814,
+        "narHash": "sha256-OUVNmUCUk4G2ur+O/Q6Ji77iHQeN3PufmiPDz9MS8AY=",
         "owner": "holochain",
         "repo": "holochain",
-        "rev": "97d86050b177829b623461970db5c3b64fbd74c1",
+        "rev": "63aeec5fd95b3263bc8ebce73c53b9f0e03bbf36",
         "type": "github"
       },
       "original": {
         "owner": "holochain",
-        "ref": "holochain-0.3.2",
+        "ref": "holochain-0.3.3",
         "repo": "holochain",
         "type": "github"
       }
@@ -274,11 +293,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1727194089,
-        "narHash": "sha256-+KmoByZhktCuJHNqYiZYedvSwhjgzLev0F0NcKNHgMY=",
+        "lastModified": 1727888522,
+        "narHash": "sha256-v7xvwPMeIUkYnPuMG+uypRu259t1HoSYBY+1zaq8jHs=",
         "owner": "holochain",
         "repo": "holonix",
-        "rev": "0aeff9984ab60ea70df3812be605a5f455f0489b",
+        "rev": "9d3c4cf95e0224a953de9a290d055e494113e42b",
         "type": "github"
       },
       "original": {
@@ -300,11 +319,11 @@
         "rust-overlay": "rust-overlay_2"
       },
       "locked": {
-        "lastModified": 1727194089,
-        "narHash": "sha256-+KmoByZhktCuJHNqYiZYedvSwhjgzLev0F0NcKNHgMY=",
+        "lastModified": 1728321646,
+        "narHash": "sha256-Wi6LEXhmErD4P4wELAcLP5z/keH7EeYl6zpWQzXXvsk=",
         "owner": "holochain",
         "repo": "holonix",
-        "rev": "0aeff9984ab60ea70df3812be605a5f455f0489b",
+        "rev": "a3252429407995fae1987be1a0391504f8e40269",
         "type": "github"
       },
       "original": {
@@ -350,11 +369,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1727634051,
-        "narHash": "sha256-S5kVU7U82LfpEukbn/ihcyNt2+EvG7Z5unsKW9H/yFA=",
+        "lastModified": 1720768451,
+        "narHash": "sha256-EYekUHJE2gxeo2pM/zM9Wlqw1Uw2XTJXOSAO79ksc4Y=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "06cf0e1da4208d3766d898b7fdab6513366d45b9",
+        "rev": "7e7c39ea35c5cdd002cd4588b03a3fb9ece6fad9",
         "type": "github"
       },
       "original": {
@@ -378,14 +397,14 @@
     },
     "nixpkgs-lib_2": {
       "locked": {
-        "lastModified": 1725233747,
-        "narHash": "sha256-Ss8QWLXdr2JCBPcYChJhz4xJm+h/xjl4G0c0XlP6a74=",
+        "lastModified": 1727825735,
+        "narHash": "sha256-0xHYkMkeLVQAMa7gvkddbPqpxph+hDzdu1XdGPJR+Os=",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/356624c12086a18f2ea2825fed34523d60ccc4e3.tar.gz"
+        "url": "https://github.com/NixOS/nixpkgs/archive/fb192fec7cc7a4c26d51779e9bab07ce6fa5597a.tar.gz"
       },
       "original": {
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/356624c12086a18f2ea2825fed34523d60ccc4e3.tar.gz"
+        "url": "https://github.com/NixOS/nixpkgs/archive/fb192fec7cc7a4c26d51779e9bab07ce6fa5597a.tar.gz"
       }
     },
     "nixpkgs_2": {
@@ -422,11 +441,11 @@
     },
     "pnpmnixpkgs": {
       "locked": {
-        "lastModified": 1727264057,
-        "narHash": "sha256-KQPI8CTTnB9CrJ7LrmLC4VWbKZfljEPBXOFGZFRpxao=",
+        "lastModified": 1727907660,
+        "narHash": "sha256-QftbyPoieM5M50WKUMzQmWtBWib/ZJbHo7mhj5riQec=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "759537f06e6999e141588ff1c9be7f3a5c060106",
+        "rev": "5966581aa04be7eff830b9e1457d56dc70a0b798",
         "type": "github"
       },
       "original": {
@@ -486,11 +505,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1725243956,
-        "narHash": "sha256-0A5ZP8uDCyBdYUzayZfy6JFdTefP79oZVAjyqA/yuSI=",
+        "lastModified": 1728268235,
+        "narHash": "sha256-lJMFnMO4maJuNO6PQ5fZesrTmglze3UFTTBuKGwR1Nw=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "a10c8092d5f82622be79ed4dd12289f72011f850",
+        "rev": "25685cc2c7054efc31351c172ae77b21814f2d42",
         "type": "github"
       },
       "original": {
@@ -500,6 +519,21 @@
       }
     },
     "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_2": {
       "locked": {
         "lastModified": 1681028828,
         "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",

--- a/flake.lock
+++ b/flake.lock
@@ -23,11 +23,11 @@
     },
     "crane": {
       "locked": {
-        "lastModified": 1725125250,
-        "narHash": "sha256-CB20rDD5eHikF6mMTTJdwPP1qvyoiyyw1RDUzwIaIF8=",
+        "lastModified": 1727974419,
+        "narHash": "sha256-WD0//20h+2/yPGkO88d2nYbb23WMWYvnRyDQ9Dx4UHg=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "96fd12c7100e9e05fa1a0a5bd108525600ce282f",
+        "rev": "37e4f9f0976cb9281cd3f0c70081e5e0ecaee93f",
         "type": "github"
       },
       "original": {
@@ -78,11 +78,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1725234343,
-        "narHash": "sha256-+ebgonl3NbiKD2UD0x4BszCZQ6sTfL4xioaM49o5B3Y=",
+        "lastModified": 1727826117,
+        "narHash": "sha256-K5ZLCyfO/Zj9mPFldf3iwS6oZStJcU4tSpiXTMYaaL0=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "567b938d64d4b4112ee253b9274472dc3a346eb6",
+        "rev": "3d04084d54bedc3d6b8b736c70ef449225c361b1",
         "type": "github"
       },
       "original": {
@@ -166,11 +166,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1728680310,
-        "narHash": "sha256-43nvdSVyI5fe6MQjzM00jb7oSCxLmKQclqvYsWCmMTE=",
+        "lastModified": 1728681607,
+        "narHash": "sha256-DkDAlxX1JS8Bd1gsNrqxC1GjYdV2Vy6Wgoa69i+kMhA=",
         "owner": "holochain-open-dev",
         "repo": "infrastructure",
-        "rev": "6e49ab461291f6d6dfbb64945cc9210cbf7653e3",
+        "rev": "9d5091f2ddc1c6bc2291c59b23a6a034dc0c6ffd",
         "type": "github"
       },
       "original": {
@@ -251,16 +251,16 @@
     "holochain": {
       "flake": false,
       "locked": {
-        "lastModified": 1722347117,
-        "narHash": "sha256-Jv4DxaVtdbO+fOD4woFoepCCOtRN/HF94xJSwViz3ck=",
+        "lastModified": 1728056814,
+        "narHash": "sha256-OUVNmUCUk4G2ur+O/Q6Ji77iHQeN3PufmiPDz9MS8AY=",
         "owner": "holochain",
         "repo": "holochain",
-        "rev": "97d86050b177829b623461970db5c3b64fbd74c1",
+        "rev": "63aeec5fd95b3263bc8ebce73c53b9f0e03bbf36",
         "type": "github"
       },
       "original": {
         "owner": "holochain",
-        "ref": "holochain-0.3.2",
+        "ref": "holochain-0.3.3",
         "repo": "holochain",
         "type": "github"
       }
@@ -294,11 +294,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1727888522,
-        "narHash": "sha256-v7xvwPMeIUkYnPuMG+uypRu259t1HoSYBY+1zaq8jHs=",
+        "lastModified": 1728321646,
+        "narHash": "sha256-Wi6LEXhmErD4P4wELAcLP5z/keH7EeYl6zpWQzXXvsk=",
         "owner": "holochain",
         "repo": "holonix",
-        "rev": "9d3c4cf95e0224a953de9a290d055e494113e42b",
+        "rev": "a3252429407995fae1987be1a0391504f8e40269",
         "type": "github"
       },
       "original": {
@@ -386,14 +386,14 @@
     },
     "nixpkgs-lib": {
       "locked": {
-        "lastModified": 1725233747,
-        "narHash": "sha256-Ss8QWLXdr2JCBPcYChJhz4xJm+h/xjl4G0c0XlP6a74=",
+        "lastModified": 1727825735,
+        "narHash": "sha256-0xHYkMkeLVQAMa7gvkddbPqpxph+hDzdu1XdGPJR+Os=",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/356624c12086a18f2ea2825fed34523d60ccc4e3.tar.gz"
+        "url": "https://github.com/NixOS/nixpkgs/archive/fb192fec7cc7a4c26d51779e9bab07ce6fa5597a.tar.gz"
       },
       "original": {
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/356624c12086a18f2ea2825fed34523d60ccc4e3.tar.gz"
+        "url": "https://github.com/NixOS/nixpkgs/archive/fb192fec7cc7a4c26d51779e9bab07ce6fa5597a.tar.gz"
       }
     },
     "nixpkgs-lib_2": {
@@ -442,11 +442,11 @@
     },
     "pnpmnixpkgs": {
       "locked": {
-        "lastModified": 1727907660,
-        "narHash": "sha256-QftbyPoieM5M50WKUMzQmWtBWib/ZJbHo7mhj5riQec=",
+        "lastModified": 1728500571,
+        "narHash": "sha256-dOymOQ3AfNI4Z337yEwHGohrVQb4yPODCW9MDUyAc4w=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "5966581aa04be7eff830b9e1457d56dc70a0b798",
+        "rev": "d51c28603def282a24fa034bcb007e2bcb5b5dd0",
         "type": "github"
       },
       "original": {
@@ -485,11 +485,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1725243956,
-        "narHash": "sha256-0A5ZP8uDCyBdYUzayZfy6JFdTefP79oZVAjyqA/yuSI=",
+        "lastModified": 1728268235,
+        "narHash": "sha256-lJMFnMO4maJuNO6PQ5fZesrTmglze3UFTTBuKGwR1Nw=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "a10c8092d5f82622be79ed4dd12289f72011f850",
+        "rev": "25685cc2c7054efc31351c172ae77b21814f2d42",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -166,15 +166,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1728573856,
-        "narHash": "sha256-XlnTbS45DKtlHjhc3KT2lqlEn86dxEMcmcHobDn69Zc=",
+        "lastModified": 1728680157,
+        "narHash": "sha256-4rfZbfkRv0/9gnC6flPPA60r8fuXL92l7xA3y3kCBNo=",
         "owner": "holochain-open-dev",
         "repo": "infrastructure",
-        "rev": "e342ffa8d1304205a0f5a339d00923243a2bd309",
+        "rev": "2f79c1526ee43c689927c4ecee59b6ee2155421d",
         "type": "github"
       },
       "original": {
         "owner": "holochain-open-dev",
+        "ref": "fix/aarch64-darwin-does-not-exist",
         "repo": "infrastructure",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -240,7 +240,9 @@
         };
 
         packages.tauriHappCargoArtifacts = let
-          rust = inputs.holonix.packages.${system}.rust;
+          overlays = [ (import inputs.rust-overlay) ];
+          rustPkgs = import pkgs.path { inherit system overlays; };
+          rust = rustPkgs.rust-bin.stable."1.78.0".default;
           craneLib = (inputs.crane.mkLib pkgs).overrideToolchain rust;
         in craneLib.callPackage ./nix/holochain-tauri-happ-artifacts.nix {
           inherit craneLib;
@@ -314,7 +316,9 @@
         };
 
         devShells.tauriAndroidDev = let
-          rust = inputs.holonix.packages.${system}.rust.override {
+          overlays = [ (import inputs.rust-overlay) ];
+          rustPkgs = import pkgs.path { inherit system overlays; };
+          rust = rustPkgs.rust-bin.stable."1.78.0".default.override {
             extensions = [ "rust-src" ];
             targets = [
               "armv7-linux-androideabi"
@@ -344,7 +348,9 @@
           ]);
 
         packages.tauriRust = let
-          rust = inputs.holonix.packages.${system}.rust.override {
+          overlays = [ (import inputs.rust-overlay) ];
+          rustPkgs = import pkgs.path { inherit system overlays; };
+          rust = rustPkgs.rust-bin.stable."1.78.0".default.override {
             extensions = [ "rust-src" ];
           };
           linuxCargo = pkgs.writeShellApplication {
@@ -361,7 +367,9 @@
         in if pkgs.stdenv.isLinux then linuxRust else rust;
 
         packages.holochainTauriRust = let
-          rust = inputs.holonix.packages.${system}.rust.override {
+          overlays = [ (import inputs.rust-overlay) ];
+          rustPkgs = import pkgs.path { inherit system overlays; };
+          rust = rustPkgs.rust-bin.stable."1.78.0".default.override {
             extensions = [ "rust-src" ];
             targets = [ "wasm32-unknown-unknown" ];
           };
@@ -379,7 +387,9 @@
         in if pkgs.stdenv.isLinux then linuxRust else rust;
 
         packages.androidTauriRust = let
-          rust = inputs.holonix.packages.${system}.rust.override {
+          overlays = [ (import inputs.rust-overlay) ];
+          rustPkgs = import pkgs.path { inherit system overlays; };
+          rust = rustPkgs.rust-bin.stable."1.78.0".default.override {
             extensions = [ "rust-src" ];
             targets = [
               "armv7-linux-androideabi"

--- a/flake.nix
+++ b/flake.nix
@@ -483,7 +483,7 @@
 
         devShells.default = pkgs.mkShell {
           inputsFrom = [
-            inputs'.hc-infra.devShells.synchronized-pnpm
+            # inputs'.hc-infra.devShells.synchronized-pnpm
             devShells.holochainTauriDev
           ];
         };

--- a/flake.nix
+++ b/flake.nix
@@ -483,7 +483,7 @@
 
         devShells.default = pkgs.mkShell {
           inputsFrom = [
-            # inputs'.hc-infra.devShells.synchronized-pnpm
+            inputs'.hc-infra.devShells.synchronized-pnpm
             devShells.holochainTauriDev
           ];
         };

--- a/flake.nix
+++ b/flake.nix
@@ -143,7 +143,10 @@
         inputs.hc-infra.outputs.dependencies
       ];
 
-      systems = builtins.attrNames inputs.holonix.devShells;
+      #systems = builtins.attrNames inputs.holonix.devShells;
+      
+      systems = [ "x86_64-linux" "x86_64-darwin" "aarch64-linux" ];
+
       perSystem = { inputs', config, self', pkgs, system, lib, ... }: rec {
         dependencies.tauriApp = let
 

--- a/flake.nix
+++ b/flake.nix
@@ -11,7 +11,8 @@
     android-nixpkgs.url =
       "github:tadfisher/android-nixpkgs/4aeeeec599210e54aee0ac31d4fcb512f87351a0";
 
-    hc-infra.url = "github:holochain-open-dev/infrastructure";
+    #hc-infra.url = "github:holochain-open-dev/infrastructure";
+    hc-infra.url = "github:holochain-open-dev/infrastructure?ref=fix/aarch64-darwin-does-not-exist";
     crane.follows = "holonix/crane";
   };
 

--- a/flake.nix
+++ b/flake.nix
@@ -145,7 +145,7 @@
 
       #systems = builtins.attrNames inputs.holonix.devShells;
       
-      systems = [ "x86_64-linux" "x86_64-darwin" "aarch64-linux" ];
+      systems = [ "x86_64-linux" ];
 
       perSystem = { inputs', config, self', pkgs, system, lib, ... }: rec {
         dependencies.tauriApp = let

--- a/flake.nix
+++ b/flake.nix
@@ -152,7 +152,7 @@
 
           # TODO: remove this line when this bug is fixed: https://github.com/tauri-apps/tauri/issues/10626
           # and this other bug as well: https://github.com/tauri-apps/tauri/issues/9304
-          pkgs = import inputs.webkitgtknixpkgs { inherit system; };
+          # pkgs = import inputs.webkitgtknixpkgs { inherit system; };
 
           customGlib =
             pkgs.runCommandLocal "custom-glib" { src = pkgs.glib.dev; } ''

--- a/flake.nix
+++ b/flake.nix
@@ -140,7 +140,7 @@
         ./nix/modules/custom-go-compiler.nix
         ./nix/modules/tauri-cli.nix
         # inputs.hc-infra.outputs.builders
-        # inputs.hc-infra.outputs.dependencies
+        inputs.hc-infra.outputs.dependencies
       ];
 
       systems = builtins.attrNames inputs.holonix.devShells;

--- a/flake.nix
+++ b/flake.nix
@@ -138,8 +138,8 @@
         ./crates/hc-pilot/default.nix
         ./nix/modules/custom-go-compiler.nix
         ./nix/modules/tauri-cli.nix
-        # inputs.hc-infra.outputs.flake.flakeModules.builders
-        inputs.hc-infra.outputs.flake.flakeModules.dependencies
+        # inputs.hc-infra.outputs.builders
+        inputs.hc-infra.outputs.dependencies
       ];
 
       systems = builtins.attrNames inputs.holonix.devShells;

--- a/flake.nix
+++ b/flake.nix
@@ -243,7 +243,7 @@
         packages.tauriHappCargoArtifacts = let
           overlays = [ (import inputs.rust-overlay) ];
           rustPkgs = import pkgs.path { inherit system overlays; };
-          rust = rustPkgs.rust-bin.stable."1.78.0".default;
+          rust = rustPkgs.rust-bin.stable."1.79.0".default;
           craneLib = (inputs.crane.mkLib pkgs).overrideToolchain rust;
         in craneLib.callPackage ./nix/holochain-tauri-happ-artifacts.nix {
           inherit craneLib;
@@ -319,7 +319,7 @@
         devShells.tauriAndroidDev = let
           overlays = [ (import inputs.rust-overlay) ];
           rustPkgs = import pkgs.path { inherit system overlays; };
-          rust = rustPkgs.rust-bin.stable."1.78.0".default.override {
+          rust = rustPkgs.rust-bin.stable."1.79.0".default.override {
             extensions = [ "rust-src" ];
             targets = [
               "armv7-linux-androideabi"
@@ -351,7 +351,7 @@
         packages.tauriRust = let
           overlays = [ (import inputs.rust-overlay) ];
           rustPkgs = import pkgs.path { inherit system overlays; };
-          rust = rustPkgs.rust-bin.stable."1.78.0".default.override {
+          rust = rustPkgs.rust-bin.stable."1.79.0".default.override {
             extensions = [ "rust-src" ];
           };
           linuxCargo = pkgs.writeShellApplication {
@@ -370,7 +370,7 @@
         packages.holochainTauriRust = let
           overlays = [ (import inputs.rust-overlay) ];
           rustPkgs = import pkgs.path { inherit system overlays; };
-          rust = rustPkgs.rust-bin.stable."1.78.0".default.override {
+          rust = rustPkgs.rust-bin.stable."1.79.0".default.override {
             extensions = [ "rust-src" ];
             targets = [ "wasm32-unknown-unknown" ];
           };
@@ -390,7 +390,7 @@
         packages.androidTauriRust = let
           overlays = [ (import inputs.rust-overlay) ];
           rustPkgs = import pkgs.path { inherit system overlays; };
-          rust = rustPkgs.rust-bin.stable."1.78.0".default.override {
+          rust = rustPkgs.rust-bin.stable."1.79.0".default.override {
             extensions = [ "rust-src" ];
             targets = [
               "armv7-linux-androideabi"

--- a/flake.nix
+++ b/flake.nix
@@ -140,19 +140,16 @@
         ./nix/modules/custom-go-compiler.nix
         ./nix/modules/tauri-cli.nix
         # inputs.hc-infra.outputs.builders
-        inputs.hc-infra.outputs.dependencies
+        # inputs.hc-infra.outputs.dependencies
       ];
 
-      #systems = builtins.attrNames inputs.holonix.devShells;
-      
-      systems = [ "x86_64-linux" ];
-
+      systems = builtins.attrNames inputs.holonix.devShells;
       perSystem = { inputs', config, self', pkgs, system, lib, ... }: rec {
         dependencies.tauriApp = let
 
           # TODO: remove this line when this bug is fixed: https://github.com/tauri-apps/tauri/issues/10626
           # and this other bug as well: https://github.com/tauri-apps/tauri/issues/9304
-          # pkgs = import inputs.webkitgtknixpkgs { inherit system; };
+          pkgs = import inputs.webkitgtknixpkgs { inherit system; };
 
           customGlib =
             pkgs.runCommandLocal "custom-glib" { src = pkgs.glib.dev; } ''

--- a/flake.nix
+++ b/flake.nix
@@ -138,8 +138,8 @@
         ./crates/hc-pilot/default.nix
         ./nix/modules/custom-go-compiler.nix
         ./nix/modules/tauri-cli.nix
-        # inputs.hc-infra.outputs.flakeModules.builders
-        inputs.hc-infra.outputs.flakeModules.dependencies
+        # inputs.hc-infra.outputs.flake.flakeModules.builders
+        inputs.hc-infra.outputs.flake.flakeModules.dependencies
       ];
 
       systems = builtins.attrNames inputs.holonix.devShells;

--- a/nix/reference-tauri-happ/Cargo.toml
+++ b/nix/reference-tauri-happ/Cargo.toml
@@ -21,7 +21,7 @@ tauri-build = { version = "2.0.0", default-features = false, features = [
 [dependencies]
 tauri = { version = "2", features = [] }
 tauri-plugin-holochain = { path = "../../crates/tauri-plugin-holochain" }
-holochain_types = { version = "0.3.2" }
+holochain_types = { version = "0.3.3" }
 lair_keystore = { version = "0.4.5" }
 holochain_client = { version = "0.5.1" }
 log = "0.4"

--- a/nix/reference-tauri-happ/Cargo.toml
+++ b/nix/reference-tauri-happ/Cargo.toml
@@ -19,7 +19,7 @@ tauri-build = { version = "2.0.0", default-features = false, features = [
 ] }
 
 [dependencies]
-tauri = { version = "2.0.0", features = [] }
+tauri = { version = "2", features = [] }
 tauri-plugin-holochain = { path = "../../crates/tauri-plugin-holochain" }
 holochain_types = { version = "0.3.2" }
 lair_keystore = { version = "0.4.5" }


### PR DESCRIPTION
- tauri crates now require rust 1.78.0, while holonix 0.3 is on rust 1.77
- loosen tauri crate version pinning to major releases -- I think they're good about semver