### PR TITLE
fix: don't require connection to signal server on launch

### DIFF
--- a/crates/tauri-plugin-holochain/src/launch.rs
+++ b/crates/tauri-plugin-holochain/src/launch.rs
@@ -10,7 +10,7 @@ use holochain_client::AdminWebsocket;
 
 use crate::{
     filesystem::FileSystem,
-    launch::signal::{can_connect_to_signal_server, run_local_signal_service},
+    launch::signal::run_local_signal_service,
     HolochainPluginConfig, HolochainRuntime,
 };
 

--- a/crates/tauri-plugin-holochain/src/launch.rs
+++ b/crates/tauri-plugin-holochain/src/launch.rs
@@ -59,17 +59,6 @@ pub async fn launch_holochain_runtime(
         portpicker::pick_unused_port().expect("No ports free")
     };
 
-    let wan_network_config = if let Some(network_config) = config.wan_network_config {
-        if let Err(err) = can_connect_to_signal_server(network_config.signal_url.clone()).await {
-            log::error!("Error connecting to the WAN signal server: {err:?}");
-            None
-        } else {
-            Some(network_config)
-        }
-    } else {
-        None
-    };
-
     // Run local signal server
     let my_local_ip = local_ip_address::local_ip().expect("Could not get local ip address");
     let port = portpicker::pick_unused_port().expect("No ports free");
@@ -81,7 +70,7 @@ pub async fn launch_holochain_runtime(
         &filesystem,
         admin_port,
         filesystem.keystore_dir().into(),
-        wan_network_config,
+        config.wan_network_config,
         local_signal_url,
         override_gossip_arc_clamping(),
     );

--- a/crates/tauri-plugin-holochain/src/launch/signal.rs
+++ b/crates/tauri-plugin-holochain/src/launch/signal.rs
@@ -3,23 +3,6 @@ use std::sync::Arc;
 use sbd_server::{Config, SbdServer};
 use url2::Url2;
 
-pub async fn can_connect_to_signal_server(signal_url: Url2) -> std::io::Result<()> {
-    let config = tx5_signal::SignalConfig {
-        listener: false,
-        allow_plain_text: true,
-        ..Default::default()
-    };
-    let signal_url_str = if let Some(s) = signal_url.as_str().strip_suffix('/') {
-        s
-    } else {
-        signal_url.as_str()
-    };
-
-    tx5_signal::SignalConnection::connect(signal_url_str, Arc::new(config)).await?;
-
-    Ok(())
-}
-
 pub async fn run_local_signal_service(local_ip: String, port: u16) -> std::io::Result<SbdServer> {
     let mut config = Config::default();
 


### PR DESCRIPTION
I don't think it makes sense to require connectivity to the signal server on launch.

If the user launches the app without a network connection, then enables a network connection later, I don't want them to be restricted to their LAN until they restart the app.