### PR TITLE
feat: disable dpki until it becomes a stable feature of holochain

### DIFF
--- a/crates/holochain_runtime/src/launch/config.rs
+++ b/crates/holochain_runtime/src/launch/config.rs
@@ -4,6 +4,7 @@ use holochain::conductor::{
     config::{AdminInterfaceConfig, ConductorConfig, KeystoreConfig},
     interface::InterfaceDriver,
 };
+use holochain_conductor_api::conductor::DpkiConfig;
 use holochain_keystore::paths::KeystorePath;
 use holochain_types::websocket::AllowedOrigins;
 use kitsune_p2p_types::config::{
@@ -27,7 +28,8 @@ pub fn conductor_config(
         lair_root: Some(lair_root),
     };
     config.device_seed_lair_tag = Some(DEVICE_SEED_LAIR_KEYSTORE_TAG.into());
-
+    config.dpki = DpkiConfig::disabled();
+    
     let mut network_config = KitsuneP2pConfig::default();
 
     let mut tuning_params = KitsuneP2pTuningParams::default();


### PR DESCRIPTION
Re-opening this as I need it. I don't think it will change with the 0.4 release.

I don't think it makes sense to expose the configuration yet, as dpki is now disabled behind a feature flag in holochain 0.4, and even if enabled is still an incomplete feature since we functions to update keys are not in the hdk yet.