### PR TITLE
publish ZOME_CALL_SIGNER_INITIALIZATION_SCRIPT

### DIFF
--- a/crates/tauri-plugin-holochain/src/lib.rs
+++ b/crates/tauri-plugin-holochain/src/lib.rs
@@ -25,7 +25,7 @@ pub use error::{Error, Result};
 use hc_live_file::*;
 pub use holochain_runtime::*;
 
-const ZOME_CALL_SIGNER_INITIALIZATION_SCRIPT: &'static str = include_str!("../zome-call-signer.js");
+pub const ZOME_CALL_SIGNER_INITIALIZATION_SCRIPT: &'static str = include_str!("../zome-call-signer.js");
 
 /// Access to the holochain APIs.
 pub struct HolochainPlugin<R: Runtime> {


### PR DESCRIPTION
this is needed to allow manual tauri window creation