### PR TITLE
Refactor/split install_app and enable_app steps

### DIFF
--- a/crates/holochain_runtime/src/happs/install.rs
+++ b/crates/holochain_runtime/src/happs/install.rs
@@ -52,6 +52,15 @@ pub async fn install_app(
         .map_err(|err| crate::Error::ConductorApiError(err))?;
     log::info!("Installed app {app_info:?}");
 
+    Ok(response.app)
+}
+
+pub async fn enable_app(
+    admin_ws: &AdminWebsocket,
+    app_id: String,
+) -> crate::Result<AppInfo> {
+    log::info!("Enabling app {}", app_id);
+
     let response = admin_ws
         .enable_app(app_id.clone())
         .await

--- a/crates/holochain_runtime/src/happs/install.rs
+++ b/crates/holochain_runtime/src/happs/install.rs
@@ -61,12 +61,12 @@ pub async fn enable_app(
 ) -> crate::Result<AppInfo> {
     log::info!("Enabling app {}", app_id);
 
-    let response = admin_ws
+    let res = admin_ws
         .enable_app(app_id.clone())
         .await
         .map_err(|err| crate::Error::ConductorApiError(err))?;
 
     log::info!("Enabled app {app_id:?}");
 
-    Ok(response.app)
+    Ok(res.app)
 }

--- a/crates/holochain_runtime/src/happs/install.rs
+++ b/crates/holochain_runtime/src/happs/install.rs
@@ -52,7 +52,7 @@ pub async fn install_app(
         .map_err(|err| crate::Error::ConductorApiError(err))?;
     log::info!("Installed app {app_info:?}");
 
-    Ok(response.app)
+    Ok(app_info)
 }
 
 pub async fn enable_app(
@@ -61,12 +61,12 @@ pub async fn enable_app(
 ) -> crate::Result<AppInfo> {
     log::info!("Enabling app {}", app_id);
 
-    let res = admin_ws
+    let response = admin_ws
         .enable_app(app_id.clone())
         .await
         .map_err(|err| crate::Error::ConductorApiError(err))?;
 
     log::info!("Enabled app {app_id:?}");
 
-    Ok(res.app)
+    Ok(response.app)
 }

--- a/crates/holochain_runtime/src/holochain_runtime.rs
+++ b/crates/holochain_runtime/src/holochain_runtime.rs
@@ -7,7 +7,7 @@ use holochain_types::{app::{AppBundle, RoleSettings}, web_app::WebAppBundle, web
 use lair_keystore::dependencies::sodoken::BufRead;
 use sbd_server::SbdServer;
 
-use crate::{filesystem::{AppBundleStore, BundleStore, FileSystem}, happs::{install::{install_app, install_web_app}, update::{update_app, UpdateHappError}}, lair_signer::LairAgentSignerWithProvenance, launch::launch_holochain_runtime, sign_zome_call_with_client, HolochainRuntimeConfig};
+use crate::{filesystem::{AppBundleStore, BundleStore, FileSystem}, happs::{install::{install_app, enable_app, install_web_app}, update::{update_app, UpdateHappError}}, lair_signer::LairAgentSignerWithProvenance, launch::launch_holochain_runtime, sign_zome_call_with_client, HolochainRuntimeConfig};
 
 #[derive(Clone)]
 pub struct AppWebsocketAuth {

--- a/crates/holochain_runtime/src/holochain_runtime.rs
+++ b/crates/holochain_runtime/src/holochain_runtime.rs
@@ -344,13 +344,12 @@ impl HolochainRuntime {
     pub async fn enable_app(
         &self,
         app_id: InstalledAppId
-    ) -> crate::Result<()> {
+    ) -> crate::Result<AppInfo> {
         let admin_ws = self.admin_websocket().await?;
-        admin_ws.enable_app(app_id)
-            .await
-            .map_err(|e| crate::Error::ConductorApiError(e))?;
+        let app_info = enable_app(&admin_ws, app_id)
+            .await?;
 
-        Ok(())
+        Ok(app_info)
     }
 
     /// Disable the app with the given `app_id` from the holochain conductor

--- a/crates/scaffold-tauri-happ/templates/end-user-happ/src-tauri/src/lib.rs.hbs
+++ b/crates/scaffold-tauri-happ/templates/end-user-happ/src-tauri/src/lib.rs.hbs
@@ -79,6 +79,13 @@ async fn setup(handle: AppHandle) -> anyhow::Result<()> {
             )
             .await?;
 
+        handle
+            .holochain()?
+            .enable_app(
+                String::from(APP_ID)
+            )
+            .await?;
+
         Ok(())
     } else {
         handle.holochain()?.update_app_if_necessary(

--- a/crates/tauri-plugin-holochain/src/lib.rs
+++ b/crates/tauri-plugin-holochain/src/lib.rs
@@ -259,6 +259,22 @@ impl<R: Runtime> HolochainPlugin<R> {
         Ok(app_info)
     }
 
+    /// Enable the app with the given `app_id`
+    ///
+    /// * `app_id` - the app id to give to the installed app
+    pub async fn enable_app(
+        &self,
+        app_id: InstalledAppId
+    ) -> crate::Result<AppInfo> {
+        let app_info = self.holochain_runtime.enable_app(
+            app_id.clone(),
+        )
+        .await?;
+
+        self.app_handle.emit("holochain://app-enabled", app_id)?;
+        Ok(app_info)
+    }
+
     /// Updates the coordinator zomes and UI for the given app with an updated `WebAppBundle`
     ///
     /// * `app_id` - the app to update

--- a/examples/end-user-happ/src-tauri/src/lib.rs
+++ b/examples/end-user-happ/src-tauri/src/lib.rs
@@ -122,6 +122,13 @@ async fn setup(handle: AppHandle) -> anyhow::Result<()> {
             )
             .await?;
 
+        handle
+            .holochain()?
+            .enable_app(
+                String::from(APP_ID),
+            )
+            .await?;
+
         Ok(())
     } else {
         handle.holochain()?.update_app_if_necessary(


### PR DESCRIPTION
This splits up `install_app` and `enable_app` into separate steps. And pushes it up to the tauri app to call each sequentially.

Apps with `allow_deferred_memproofs: true` cannot immediately enable the installed app, so they need some way of skipping the enable_app call. Alternatively we could pass an `enable: bool` field to the existing `install_app` fn to tell it to skip the `enable_app` call or not, but this seemed more flexible.