### PR TITLE
Add init_deferred + launch_holochain: register the plugin without starting lair, the conductor, or network traffic

### DIFF
--- a/.changes/init-deferred-launch.md
+++ b/.changes/init-deferred-launch.md
@@ -1,0 +1,6 @@
+---
+"tauri-plugin-holochain": 'minor:feat'
+"holochain_runtime": 'patch:enhance'
+---
+
+Add `init_deferred` + `HolochainExt::launch_holochain` to register the plugin without starting lair, the conductor, or any network traffic, and launch later (e.g. after a password gate). Adds `Error::AlreadyLaunched` / `Error::NotDeferred`; exiting before launch now shuts down cleanly. `HolochainRuntimeConfig` is now `Clone`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9660,6 +9660,7 @@ dependencies = [
  "symlink",
  "tauri",
  "tauri-plugin",
+ "tempfile",
  "thiserror 1.0.69",
  "tls-listener",
  "tokio",

--- a/crates/holochain_runtime/src/config.rs
+++ b/crates/holochain_runtime/src/config.rs
@@ -1,6 +1,7 @@
 use holochain_conductor_api::conductor::NetworkConfig;
 use std::path::PathBuf;
 
+#[derive(Clone)]
 pub struct HolochainRuntimeConfig {
     /// The directory where the holochain files and databases will be stored in
     pub holochain_dir: PathBuf,

--- a/crates/tauri-plugin-holochain/Cargo.toml
+++ b/crates/tauri-plugin-holochain/Cargo.toml
@@ -41,6 +41,11 @@ either = "*"
 anyhow = "1"
 tokio = "1"
 
+[dev-dependencies]
+tauri = { version = "2.1.1", features = ["test"] }
+tokio = { version = "1", features = ["macros", "rt-multi-thread", "net", "time"] }
+tempfile = "3"
+
 [build-dependencies]
 tauri-plugin = { version = "2.0.0", features = ["build"] }
 

--- a/crates/tauri-plugin-holochain/src/error.rs
+++ b/crates/tauri-plugin-holochain/src/error.rs
@@ -44,6 +44,12 @@ pub enum Error {
 
     #[error("Holochain has not been initialized yet")]
     HolochainNotInitializedError,
+
+    #[error("Holochain was already launched")]
+    AlreadyLaunched,
+
+    #[error("The plugin was not registered with init_deferred")]
+    NotDeferred,
 }
 
 impl Serialize for Error {

--- a/crates/tauri-plugin-holochain/src/lib.rs
+++ b/crates/tauri-plugin-holochain/src/lib.rs
@@ -369,6 +369,17 @@ impl<R: Runtime> HolochainPlugin<R> {
 // Extensions to [`tauri::App`], [`tauri::AppHandle`] and [`tauri::Window`] to access the holochain APIs.
 pub trait HolochainExt<R: Runtime> {
     fn holochain(&self) -> crate::Result<&HolochainPlugin<R>>;
+
+    /// Launches lair + the conductor with the config stashed by
+    /// [`init_deferred`], emitting `holochain://setup-completed` on success and
+    /// `holochain://setup-failed` on failure (the [`async_init`] contract).
+    /// A failed launch restores the config, so the call can be retried.
+    /// Errors: [`Error::NotDeferred`] if not registered via `init_deferred`;
+    /// [`Error::AlreadyLaunched`] if a launch already succeeded or is in flight.
+    fn launch_holochain(
+        &self,
+        passphrase: SharedLockedArray,
+    ) -> impl std::future::Future<Output = crate::Result<()>> + Send;
 }
 
 impl<R: Runtime, T: Manager<R>> crate::HolochainExt<R> for T {
@@ -379,6 +390,45 @@ impl<R: Runtime, T: Manager<R>> crate::HolochainExt<R> for T {
             .ok_or(crate::Error::HolochainNotInitializedError)?;
 
         Ok(s.inner())
+    }
+
+    fn launch_holochain(
+        &self,
+        passphrase: SharedLockedArray,
+    ) -> impl std::future::Future<Output = crate::Result<()>> + Send {
+        let app_handle = self.app_handle().clone();
+        async move {
+            let config = {
+                let state = app_handle
+                    .try_state::<DeferredHolochainConfig>()
+                    .ok_or(crate::Error::NotDeferred)?;
+                let mut guard = state.0.lock().map_err(|err| {
+                    crate::Error::LockError(format!(
+                        "deferred holochain config lock poisoned: {err}"
+                    ))
+                })?;
+                guard.take().ok_or(crate::Error::AlreadyLaunched)?
+            }; // guard dropped here — never held across an await
+
+            let retry_config = config.clone();
+            match launch_and_setup_holochain(app_handle.clone(), passphrase, config).await {
+                Ok(()) => Ok(()),
+                Err(err) => {
+                    if let Some(state) = app_handle.try_state::<DeferredHolochainConfig>() {
+                        if let Ok(mut guard) = state.0.lock() {
+                            *guard = Some(retry_config);
+                        }
+                    }
+                    log::error!("Failed to launch holochain: {err:?}");
+                    if let Err(emit_err) = app_handle.emit("holochain://setup-failed", ()) {
+                        log::error!(
+                            "Failed to emit \"holochain://setup-failed\" event: {emit_err:?}"
+                        );
+                    }
+                    Err(err)
+                }
+            }
+        }
     }
 }
 
@@ -514,9 +564,12 @@ fn shutdown_runtime<R: Runtime>(app: &AppHandle<R>) -> crate::Result<()> {
     let result: std::result::Result<crate::Result<()>, tokio::time::error::Elapsed> =
         tokio_helper::block_on(
             async move {
-                let holochain = app
-                    .holochain()
-                    .map_err(|_err| crate::Error::HolochainNotInitializedError)?;
+                let Ok(holochain) = app.holochain() else {
+                    // Never launched (deferred, or async_init still starting):
+                    // nothing to shut down.
+                    log::info!("Holochain was never launched: nothing to shut down.");
+                    return Ok(());
+                };
 
                 holochain.holochain_runtime.shutdown().await?;
 
@@ -565,6 +618,26 @@ pub fn async_init<R: Runtime>(
                 }
             });
 
+            Ok(())
+        })
+        .build()
+}
+
+/// Config stashed by [`init_deferred`] until [`HolochainExt::launch_holochain`]
+/// consumes it. `Some` = not launched; `None` = launched or launching; state
+/// absent = registered via [`init`]/[`async_init`]. A failed launch restores
+/// the config so launch can be retried.
+struct DeferredHolochainConfig(std::sync::Mutex<Option<HolochainPluginConfig>>);
+
+/// Registers the plugin WITHOUT launching lair or the conductor: no keystore
+/// unlock and no bootstrap/signal/relay traffic happens until
+/// [`HolochainExt::launch_holochain`] is called (e.g. after a password gate).
+/// Listen for `holochain://setup-completed` / `holochain://setup-failed`
+/// exactly as with [`async_init`]; `is_holochain_ready` stays `false` until then.
+pub fn init_deferred<R: Runtime>(config: HolochainPluginConfig) -> TauriPlugin<R> {
+    plugin_builder()
+        .setup(move |app, _api| {
+            app.manage(DeferredHolochainConfig(std::sync::Mutex::new(Some(config))));
             Ok(())
         })
         .build()

--- a/crates/tauri-plugin-holochain/src/lib.rs
+++ b/crates/tauri-plugin-holochain/src/lib.rs
@@ -722,3 +722,55 @@ async fn launch_and_setup_holochain<R: Runtime>(
 
     Ok(())
 }
+
+#[cfg(test)]
+mod deferred_tests {
+    use super::*;
+    use tauri::test::{mock_builder, mock_context, noop_assets, MockRuntime};
+
+    fn deferred_mock_app(holochain_dir: std::path::PathBuf) -> tauri::App<MockRuntime> {
+        mock_builder()
+            .plugin(init_deferred::<MockRuntime>(HolochainPluginConfig::new(
+                holochain_dir,
+                NetworkConfig::default(),
+            )))
+            .build(mock_context(noop_assets()))
+            .expect("mock app with init_deferred must build")
+    }
+
+    #[test]
+    fn deferred_registration_stashes_config_and_launches_nothing() {
+        let holochain_dir = tempfile::tempdir().expect("tempdir");
+        let app = deferred_mock_app(holochain_dir.path().into());
+
+        let stash = app
+            .try_state::<DeferredHolochainConfig>()
+            .expect("init_deferred must manage DeferredHolochainConfig");
+        assert!(stash.0.lock().expect("stash lock").is_some());
+
+        assert!(matches!(
+            app.holochain(),
+            Err(crate::Error::HolochainNotInitializedError)
+        ));
+        assert!(app.try_state::<HolochainPlugin<MockRuntime>>().is_none());
+
+        let dir_entries = std::fs::read_dir(holochain_dir.path())
+            .expect("read holochain dir")
+            .count();
+        assert_eq!(
+            dir_entries, 0,
+            "registration must not touch the holochain dir"
+        );
+    }
+
+    #[tokio::test]
+    async fn launch_on_undeferred_registration_returns_not_deferred() {
+        let app = mock_builder()
+            .plugin(plugin_builder::<MockRuntime>().build())
+            .build(mock_context(noop_assets()))
+            .expect("mock app with bare plugin must build");
+
+        let launch_result = app.launch_holochain(vec_to_locked(vec![0u8; 8])).await;
+        assert!(matches!(launch_result, Err(crate::Error::NotDeferred)));
+    }
+}

--- a/crates/tauri-plugin-holochain/tests/deferred_launch.rs
+++ b/crates/tauri-plugin-holochain/tests/deferred_launch.rs
@@ -1,0 +1,129 @@
+//! Deferred-launch contract: zero network dials before `launch_holochain`,
+//! traffic + setup-completed after, `AlreadyLaunched` on a second call.
+
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
+
+use tauri::Listener;
+use tauri_plugin_holochain::{
+    init_deferred, vec_to_locked, Error, HolochainExt, HolochainPluginConfig, NetworkConfig,
+};
+
+struct LocalEndpoints {
+    network_config: NetworkConfig,
+    accept_counts: [Arc<AtomicUsize>; 3],
+}
+
+impl LocalEndpoints {
+    fn total_accepts(&self) -> usize {
+        self.accept_counts
+            .iter()
+            .map(|count| count.load(Ordering::SeqCst))
+            .sum()
+    }
+}
+
+async fn bind_local_endpoints() -> LocalEndpoints {
+    let (bootstrap_port, bootstrap_accepts) = bind_counted_listener().await;
+    let (signal_port, signal_accepts) = bind_counted_listener().await;
+    let (relay_port, relay_accepts) = bind_counted_listener().await;
+
+    let network_config = NetworkConfig {
+        bootstrap_url: url2::url2!("http://127.0.0.1:{}", bootstrap_port),
+        signal_url: url2::url2!("ws://127.0.0.1:{}", signal_port),
+        relay_url: url2::url2!("http://127.0.0.1:{}", relay_port),
+        ..NetworkConfig::default()
+    };
+
+    LocalEndpoints {
+        network_config,
+        accept_counts: [bootstrap_accepts, signal_accepts, relay_accepts],
+    }
+}
+
+async fn bind_counted_listener() -> (u16, Arc<AtomicUsize>) {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind local listener");
+    let port = listener.local_addr().expect("local addr").port();
+    let accept_count = Arc::new(AtomicUsize::new(0));
+    let accept_count_in_loop = accept_count.clone();
+    tokio::spawn(async move {
+        loop {
+            if listener.accept().await.is_ok() {
+                accept_count_in_loop.fetch_add(1, Ordering::SeqCst);
+            }
+        }
+    });
+    (port, accept_count)
+}
+
+async fn wait_until(predicate: impl Fn() -> bool, timeout: Duration, what: &str) {
+    let deadline = tokio::time::Instant::now() + timeout;
+    while !predicate() {
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "timed out waiting for {what}"
+        );
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn launch_gates_network_and_rejects_double_launch() {
+    let endpoints = bind_local_endpoints().await;
+    let holochain_dir = tempfile::tempdir().expect("tempdir");
+    let app = tauri::test::mock_builder()
+        .plugin(init_deferred(HolochainPluginConfig::new(
+            holochain_dir.path().into(),
+            endpoints.network_config.clone(),
+        )))
+        .build(tauri::test::mock_context(tauri::test::noop_assets()))
+        .expect("mock app must build");
+
+    let setup_completed = Arc::new(AtomicBool::new(false));
+    let setup_completed_flag = setup_completed.clone();
+    app.listen("holochain://setup-completed", move |_| {
+        setup_completed_flag.store(true, Ordering::SeqCst);
+    });
+
+    tokio::time::sleep(Duration::from_secs(5)).await;
+    assert_eq!(
+        endpoints.total_accepts(),
+        0,
+        "no dial may happen before launch_holochain"
+    );
+    assert!(
+        app.holochain().is_err(),
+        "runtime must be absent before launch"
+    );
+
+    app.launch_holochain(vec_to_locked(b"test-passphrase".to_vec()))
+        .await
+        .expect("first launch must succeed");
+    assert!(
+        app.holochain().is_ok(),
+        "runtime must be present after launch"
+    );
+    wait_until(
+        || setup_completed.load(Ordering::SeqCst),
+        Duration::from_secs(10),
+        "setup-completed event",
+    )
+    .await;
+    wait_until(
+        || endpoints.total_accepts() >= 1,
+        Duration::from_secs(30),
+        "post-launch network dial",
+    )
+    .await;
+
+    let second = app
+        .launch_holochain(vec_to_locked(b"test-passphrase".to_vec()))
+        .await;
+    assert!(
+        matches!(&second, Err(Error::AlreadyLaunched)),
+        "second launch must return AlreadyLaunched, got {second:?}"
+    );
+}


### PR DESCRIPTION
Apps with a password gate need zero network activity before the user unlocks. Today both `init` and `async_init` take the passphrase at plugin registration and launch immediately — the signal/relay dial happens inside `Conductor::builder().build()`, so the first remote connection fires during Tauri setup, before first paint. There is no way to wait: the passphrase is a required registration argument, `plugin_builder()` is private, and the conductor's network config has no off switch outside `test-utils`.

This PR adds the smallest split that fixes the ordering:
- `init_deferred(config)` — registers the plugin and stashes the config. Nothing starts.
- `HolochainExt::launch_holochain(passphrase)` — runs the existing launch path and emits the existing `holochain://setup-completed` / `holochain://setup-failed` events.
- `Error::AlreadyLaunched` / `Error::NotDeferred` for misuse.

`init` and `async_init` are untouched; existing apps compile unchanged. The frontend contract is unchanged: `is_holochain_ready` + the setup events already describe the not-yet-launched window.

A failed `launch_holochain` restores the stashed config and returns the error, so a mistyped password at a login gate (#60's flow) can be retried without an app restart; `HolochainRuntimeConfig` derives `Clone` to support the restore. `shutdown_runtime` now treats a never-launched runtime as a clean no-op — before this, quitting during `async_init`'s launch window exited with code 1, and the deferred path makes that window user-visible.

Tests: config stash, not-deferred and double-launch errors, and a socket-level test that points the configured bootstrap/signal/relay URLs at local listeners and asserts zero connections before `launch_holochain` and at least one after (the conductor launches against unreachable URLs, so the test runs offline).

Context: related to #60 (user-entered lair password) — this is the launch-ordering mechanism a login page needs. #132 (expose `plugin_builder`) would let integrators build this outside the crate; this PR proposes the in-crate path so the ordering guarantee is testable here.
